### PR TITLE
Task01 Кунявская Ольга HSE

### DIFF
--- a/src/cl/aplusb.cl
+++ b/src/cl/aplusb.cl
@@ -11,12 +11,15 @@
 // - На вход дано три массива float чисел - единственное чем они отличаются от обычных указателей - модификатором __global, т.к. это глобальная память устройства (видеопамять)
 // - Четвертым и последним аргументом должно быть передано количество элементов в каждом массиве (unsigned int, главное чтобы тип был согласован с типом в соответствующем clSetKernelArg в T0D0 10)
 
-__kernel void aplusb(...)
+__kernel void aplusb(__global const float* as, __global const float* bs, __global float* cs, unsigned int n)
 {
     // Узнать какой workItem выполняется в этом потоке поможет функция get_global_id
     // см. в документации https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
     // OpenCL Compiler -> Built-in Functions -> Work-Item Functions
-
+    size_t gid = get_global_id(0);
+    if (gid < n) {
+        cs[gid] = as[gid] + bs[gid];
+    }
     // P.S. в общем случае количество элементов для сложения может быть некратно размеру WorkGroup, тогда размер рабочего пространства округлен вверх от числа элементов до кратности на размер WorkGroup
     // и в таком случае если сделать обращение к массиву просто по индексу=get_global_id(0) будет undefined behaviour (вплоть до повисания ОС)
     // поэтому нужно либо дополнить массив данных длиной до кратности размеру рабочей группы,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@ cl_device_id get_device() {
     OCL_SAFE_CALL(clGetPlatformIDs(0, nullptr, &platformsCount));
     std::vector<cl_platform_id> platforms(platformsCount);
     OCL_SAFE_CALL(clGetPlatformIDs(platformsCount, platforms.data(), nullptr));
+    cl_device_id CPU_device = 0;
 
     for (int platformIndex = 0; platformIndex < platformsCount; ++platformIndex) {
         cl_platform_id platform = platforms[platformIndex];
@@ -52,11 +53,17 @@ cl_device_id get_device() {
             if (deviceType == CL_DEVICE_TYPE_GPU) {
                 return devices[deviceIndex];
             }
+            if (deviceType == CL_DEVICE_TYPE_CPU) {
+                CPU_device = devices[deviceIndex];
+            }
         }
 
     }
+    if (CPU_device == 0) {
+        throw std::runtime_error("No CPU or GPU device available!");
+    }
 
-    throw std::runtime_error("No GPU device available!");
+    return CPU_device;
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,7 @@ int main()
     OCL_SAFE_CALL(errcode_ret);
     std::cout << "Command queue is created\n";
 
-    unsigned int n = 1000*1000;
+    unsigned int n = 100*1000*1000;
     // Создаем два массива псевдослучайных данных для сложения и массив для будущего хранения результата
     std::vector<float> as(n, 0);
     std::vector<float> bs(n, 0);
@@ -112,7 +112,7 @@ int main()
     OCL_SAFE_CALL(errcode_ret);
     cl_mem bbuf = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, sizeof(float)*n, bs.data(), &errcode_ret);
     OCL_SAFE_CALL(errcode_ret);
-    cl_mem cbuf = clCreateBuffer(context, CL_MEM_WRITE_ONLY | CL_MEM_USE_HOST_PTR, sizeof(float)*n, cs.data(), &errcode_ret);
+    cl_mem cbuf = clCreateBuffer(context, CL_MEM_WRITE_ONLY | CL_MEM_COPY_HOST_PTR, sizeof(float)*n, cs.data(), &errcode_ret);
     OCL_SAFE_CALL(errcode_ret);
     std::cout << "Buffers created\n";
 
@@ -140,28 +140,40 @@ int main()
 
     // TODO 8 Теперь скомпилируйте программу и напечатайте в консоль лог компиляции
     // см. clBuildProgram
-
+    errcode_ret = clBuildProgram(clProgram, 1, &workingDeviceID, "", nullptr, nullptr);
+    OCL_SAFE_CALL(errcode_ret);
     // А так же напечатайте лог компиляции (он будет очень полезен, если в кернеле есть синтаксические ошибки - т.е. когда clBuildProgram вернет CL_BUILD_PROGRAM_FAILURE)
     // Обратите внимание что при компиляции на процессоре через Intel OpenCL драйвер - в логе указывается какой ширины векторизацию получилось выполнить для кернела
     // см. clGetProgramBuildInfo
-//    size_t log_size = 0;
-//    std::vector<char> log(log_size, 0);
-//    if (log_size > 1) {
-//        std::cout << "Log:" << std::endl;
-//        std::cout << log.data() << std::endl;
-//    }
+
+    size_t log_size = 0;
+    OCL_SAFE_CALL(clGetProgramBuildInfo(clProgram, workingDeviceID, CL_PROGRAM_BUILD_LOG, 0, nullptr, &log_size));
+
+    std::vector<char> log(log_size, 0);
+    OCL_SAFE_CALL(clGetProgramBuildInfo(clProgram, workingDeviceID, CL_PROGRAM_BUILD_LOG, log_size, log.data(), nullptr));
+
+    if (log_size > 1) {
+        std::cout << "Log:" << std::endl;
+        std::cout << log.data() << std::endl;
+    }
 
     // TODO 9 Создайте OpenCL-kernel в созданной подпрограмме (в одной подпрограмме может быть несколько кернелов, но в данном случае кернел один)
     // см. подходящую функцию в Runtime APIs -> Program Objects -> Kernel Objects
+    cl_kernel clKernel = clCreateKernel(clProgram, "aplusb", &errcode_ret);
+    OCL_SAFE_CALL(errcode_ret);
+    std::cout << "Kernel created\n";
 
     // TODO 10 Выставите все аргументы в кернеле через clSetKernelArg (as_gpu, bs_gpu, cs_gpu и число значений, убедитесь что тип количества элементов такой же в кернеле)
     {
-        // unsigned int i = 0;
-        // clSetKernelArg(kernel, i++, ..., ...));
-        // clSetKernelArg(kernel, i++, ..., ...));
-        // clSetKernelArg(kernel, i++, ..., ...));
-        // clSetKernelArg(kernel, i++, ..., ...));
+         unsigned int arr_size = n;
+         unsigned int i = 0;
+         clSetKernelArg(clKernel, i++, sizeof(abuf), &abuf);
+         clSetKernelArg(clKernel, i++, sizeof(bbuf), &bbuf);
+         clSetKernelArg(clKernel, i++, sizeof(cbuf), &cbuf);
+         clSetKernelArg(clKernel, i++, sizeof(unsigned int), &arr_size);
     }
+
+    std::cout << "Args are set\n";
 
     // TODO 11 Выше увеличьте n с 1000*1000 до 100*1000*1000 (чтобы дальнейшие замеры были ближе к реальности)
     
@@ -177,8 +189,9 @@ int main()
         size_t global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
         timer t; // Это вспомогательный секундомер, он замеряет время своего создания и позволяет усреднять время нескольких замеров
         for (unsigned int i = 0; i < 20; ++i) {
-            // clEnqueueNDRangeKernel...
-            // clWaitForEvents...
+            cl_event event;
+            OCL_SAFE_CALL(clEnqueueNDRangeKernel(commandQueue, clKernel, 1, nullptr, &global_work_size, &workGroupSize, 0, nullptr, &event));
+            OCL_SAFE_CALL(clWaitForEvents(1, &event));
             t.nextLap(); // При вызове nextLap секундомер запоминает текущий замер (текущий круг) и начинает замерять время следующего круга
         }
         // Среднее время круга (вычисления кернела) на самом деле считаются не по всем замерам, а лишь с 20%-перцентайля по 80%-перцентайль (как и стандартное отклониение)
@@ -192,7 +205,7 @@ int main()
         // - Флопс - это число операций с плавающей точкой в секунду
         // - В гигафлопсе 10^9 флопсов
         // - Среднее время выполнения кернела равно t.lapAvg() секунд
-        std::cout << "GFlops: " << 0 << std::endl;
+        std::cout << "GFlops: " << n/(t.lapAvg()*1000*1000*1000) << std::endl;
 
         // TODO 14 Рассчитайте используемую пропускную способность обращений к видеопамяти (в гигабайтах в секунду)
         // - Всего элементов в массивах по n штук
@@ -200,26 +213,26 @@ int main()
         // - Обращений к видеопамяти т.о. 2*n*sizeof(float) байт на чтение и 1*n*sizeof(float) байт на запись, т.е. итого 3*n*sizeof(float) байт
         // - В гигабайте 1024*1024*1024 байт
         // - Среднее время выполнения кернела равно t.lapAvg() секунд
-        std::cout << "VRAM bandwidth: " << 0 << " GB/s" << std::endl;
+        std::cout << "VRAM bandwidth: " << 3*n*sizeof(float)/(t.lapAvg() * 1024*1024*1024)<< " GB/s" << std::endl;
     }
 
     // TODO 15 Скачайте результаты вычислений из видеопамяти (VRAM) в оперативную память (RAM) - из cs_gpu в cs (и рассчитайте скорость трансфера данных в гигабайтах в секунду)
     {
         timer t;
         for (unsigned int i = 0; i < 20; ++i) {
-            // clEnqueueReadBuffer...
+            OCL_SAFE_CALL(clEnqueueReadBuffer(commandQueue, cbuf, CL_TRUE, 0, n*sizeof(n), cs.data(), 0, nullptr, nullptr));
             t.nextLap();
         }
         std::cout << "Result data transfer time: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "VRAM -> RAM bandwidth: " << 0 << " GB/s" << std::endl;
+        std::cout << "VRAM -> RAM bandwidth: " << n*sizeof(float)/(t.lapAvg() * 1024*1024*1024) << " GB/s" << std::endl;
     }
 
     // TODO 16 Сверьте результаты вычислений со сложением чисел на процессоре (и убедитесь, что если в кернеле сделать намеренную ошибку, то эта проверка поймает ошибку)
-//    for (unsigned int i = 0; i < n; ++i) {
-//        if (cs[i] != as[i] + bs[i]) {
-//            throw std::runtime_error("CPU and GPU results differ!");
-//        }
-//    }
+    for (unsigned int i = 0; i < n; ++i) {
+        if (cs[i] != as[i] + bs[i]) {
+            throw std::runtime_error("CPU and GPU results differ!");
+        }
+    }
 
     clReleaseCommandQueue(commandQueue);
     clReleaseContext(context);


### PR DESCRIPTION
```
Device ID: 0x1a6e1c0
Context is created
Command queue is created
Data generated for n=100000000!
Buffers created
#ifdef __CLION_IDE__
// Этот include виден только для CLion парсера, это позволяет IDE "знать" ключевые слова вроде __kernel, __global
// а так же уметь подсказывать OpenCL методы описанные в данном инклюде (такие как get_global_id(...) и get_local_id(...))
#include "clion_defines.cl"
#endif

#line 8 // Седьмая строчка теперь восьмая (при ошибках компиляции в логе компиляции будут указаны корректные строчки благодаря этой директиве)

// TODO 5 реализуйте кернел:
// - От обычной функции кернел отличается модификатором __kernel и тем что возвращаемый тип всегда void
// - На вход дано три массива float чисел - единственное чем они отличаются от обычных указателей - модификатором __global, т.к. это глобальная память устройства (видеопамять)
// - Четвертым и последним аргументом должно быть передано количество элементов в каждом массиве (unsigned int, главное чтобы тип был согласован с типом в соответствующем clSetKernelArg в T0D0 10)

__kernel void aplusb(__global const float* as, __global const float* bs, __global float* cs, unsigned int n)
{
    // Узнать какой workItem выполняется в этом потоке поможет функция get_global_id
    // см. в документации https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
    // OpenCL Compiler -> Built-in Functions -> Work-Item Functions
    size_t gid = get_global_id(0);
    if (gid < n) {
        cs[gid] = as[gid] + bs[gid];
    }
    // P.S. в общем случае количество элементов для сложения может быть некратно размеру WorkGroup, тогда размер рабочего пространства округлен вверх от числа элементов до кратности на размер WorkGroup
    // и в таком случае если сделать обращение к массиву просто по индексу=get_global_id(0) будет undefined behaviour (вплоть до повисания ОС)
    // поэтому нужно либо дополнить массив данных длиной до кратности размеру рабочей группы,
    // либо сделать return в кернеле до обращения к данным в тех WorkItems, где get_global_id(0) выходит за границы данных (явной проверкой)
}

Programm is created
Log:
fcl build 1 succeeded.
bcl build succeeded.

Kernel created
Args are set
Kernel average time: 0.0971236+-0.000740842 s
GFlops: 1.02962
VRAM bandwidth: 11.5069 GB/s
Result data transfer time: 0.0877489+-0.00133093 s
VRAM -> RAM bandwidth: 4.2454 GB/s
```