### PR TITLE
Task03 Daniil Smirnov HSE_SPb

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -59,6 +59,9 @@ __kernel void mandelbrot(__global float* results,
     const int i = get_global_id(0);
     const int j = get_global_id(1);
 
+    if (i >= width || j >= height)
+        return;
+
     const float stepX = sizeX * 1.0f / width;
     const float stepY = sizeY * 1.0f / height;
 

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,79 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
-    // TODO если хочется избавиться от зернистости и дрожжания при интерактивном погружении - добавьте anti-aliasing:
-    // грубо говоря при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
-    // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
-    // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+float calc_mandelbrot(const float x0, const float y0, const unsigned int iters) {
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+    
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+
+        if ((x * x + y * y) > threshold2)
+            break;
+    }
+    
+    return 1.0f * iter / iters;
+}
+
+float smoothed_calc_mandelbrot(const float4 x0, const float4 y0, const unsigned int iters) {
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+    
+    float4 x = x0;
+    float4 y = y0;
+
+    int4 iterCounts = { 0, 0, 0, 0 };
+    int4 mask = { 1, 1, 1, 1 };
+
+    for (int iter = 0; iter < iters; ++iter) {
+        float4 xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+
+        mask &= ((x * x + y * y) <= threshold2);
+        iterCounts += mask;
+
+        if (all(mask))
+            break;
+    }
+    
+    return 0.25f * (iterCounts[0] + iterCounts[1] + iterCounts[2] + iterCounts[3]) / iters;
+}
+
+__kernel void mandelbrot(__global float* results, 
+                   const unsigned int width, const unsigned int height,
+                   const float fromX, const float fromY,
+                   const float sizeX, const float sizeY,
+                   const unsigned int iters, const int smoothing
+) {
+    
+    const int i = get_global_id(0);
+    const int j = get_global_id(1);
+
+    const float stepX = sizeX * 1.0f / width;
+    const float stepY = sizeY * 1.0f / height;
+
+    const float x0 = fromX + (i + 0.5f) * stepX;
+    const float y0 = fromY + (j + 0.5f) * stepY;
+
+    if (smoothing) {
+        // results[j * width + i] = (
+        //     calc_mandelbrot(x0 - stepX / 2, y0 - stepX / 2, iters) + 
+        //     calc_mandelbrot(x0 - stepX / 2, y0 + stepY / 2, iters) + 
+        //     calc_mandelbrot(x0 + stepX / 2, y0 - stepX / 2, iters) + 
+        //     calc_mandelbrot(x0 + stepX / 2, y0 + stepY / 2, iters)
+        // ) / 4;
+        const float4 smoothedX0 = { x0 - stepX / 2, x0 - stepX / 2, x0 + stepX / 2, x0 + stepX / 2 };
+        const float4 smoothedY0 = { y0 - stepY / 2, y0 + stepY / 2, y0 - stepY / 2, y0 + stepY / 2 };
+        results[j * width + i] = smoothed_calc_mandelbrot(smoothedX0, smoothedY0, iters); // not much difference compared to 4 direct computations 
+                                                                                          // also tried using computed results, but it introduced artifacts
+    } else {
+        results[j * width + i] = calc_mandelbrot(x0, y0, iters);
+    }
 }

--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -6,19 +6,14 @@
 
 typedef unsigned int index_t;
  
-void joinSegments(
-          int *sumLeft ,       int *bestSumLeft ,       index_t *bestIndexLeft,
-    const int  sumRight, const int  bestSumRight, const index_t  bestIndexRight
-) {
-    if (*bestSumLeft +  sumRight >= bestIndexRight) { // as we reversed the array the minimal maximum sum prefix would be the rightmost one, hence >=
-        *bestSumLeft += sumRight;
-        // bestIndexLeft does not change
-    } else {
-        *bestSumLeft   = bestSumRight;
-        *bestIndexLeft = bestIndexRight;
-    }
-    *sumLeft += sumRight;
-}
+#define joinSegments(sumLeft, bestSumLeft, bestIndexLeft, sumRight, bestSumRight, bestIndexRight) \
+    if (bestIndexLeft != 0 && bestSumLeft + sumRight > bestSumRight) {                           \
+        bestSumLeft += sumRight;                                                                  \
+    } else {                                                                                      \
+        bestSumLeft   = bestSumRight;                                                             \
+        bestIndexLeft = bestIndexRight;                                                           \
+    }                                                                                             \
+    sumLeft += sumRight
 
 __kernel void max_prefix_sum(
     __global const int *a, const index_t n,                                                    // input
@@ -38,60 +33,68 @@ __kernel void max_prefix_sum(
     const index_t warpCount = (groupSize + WARP_SIZE - 1) / WARP_SIZE;
 
     // setup work group stage
-    sumLocal[iGroup] = a[globalSize - iGlobal - 1];
-    bestPrefixSumLocal[iGroup] = sumLocal[iGroup];
-    bestPrefixLocal[iGroup] = globalSize - iGlobal - 1;
+    {
+        const index_t reversedIndex = globalSize - iGlobal - 1;
+        if (reversedIndex < n) {
+            sumLocal[iGroup] = a[reversedIndex];
+            bestPrefixLocal[iGroup] = reversedIndex + 1;
+        } else {
+            sumLocal[iGroup] = 0;
+            bestPrefixLocal[iGroup] = 0;
+        }
+        bestPrefixSumLocal[iGroup] = sumLocal[iGroup];
+    }
     barrier(CLK_LOCAL_MEM_FENCE);
 
     // compute values inside each warp
-    for (index_t step = 0; (1 << step) < WARP_SIZE; ++step) {
-        const index_t source = (2 * iWarp + 1) << step;
-        const index_t target = iWarp << (step + 1);
-
-        if (source < groupSize)
+    for (index_t step = 1; step < WARP_SIZE; step <<= 1) {
+        const index_t inWarpTarget = 2 * iWarp * step;
+        const index_t target = warpIndex * WARP_SIZE + inWarpTarget;
+        const index_t source = target + step;
+        
+        if (inWarpTarget + step < WARP_SIZE && source < groupSize) {
             joinSegments(
                 sumLocal[target], bestPrefixSumLocal[target], bestPrefixLocal[target],
                 sumLocal[source], bestPrefixSumLocal[source], bestPrefixLocal[source]
             );
-        // no barrier needed as we are operating within a single warp
+        }
+        // no barrier needed as we are operating within warps
     }
     barrier(CLK_LOCAL_MEM_FENCE); // synchronize
 
-    return;
-
     // join warp results pretty much the same way
     for (index_t step = WARP_SIZE; step < warpCount * WARP_SIZE; step <<= 1) {
-        const index_t target = 2 * warpIndex * step;
+        const index_t target = 2 * iGroup * step;
         const index_t source = target + step;
         
-        if (source < groupSize)
+        if (source < groupSize) {
             joinSegments(
                 sumLocal[target], bestPrefixSumLocal[target], bestPrefixLocal[target],
                 sumLocal[source], bestPrefixSumLocal[source], bestPrefixLocal[source]
             );
+        }
         barrier(CLK_LOCAL_MEM_FENCE);
     }
-
-    return;
     
     // flush results from each group to global memory
     if (iGroup == 0) {
         sum          [groupIndex] = sumLocal          [0];
-        bestPrefix   [groupIndex] = bestPrefixLocal   [0];
         bestPrefixSum[groupIndex] = bestPrefixSumLocal[0];
+        bestPrefix   [groupIndex] = bestPrefixLocal   [0];
     }
     barrier(CLK_GLOBAL_MEM_FENCE);
 
     // join group results exactly the same way as before
-    for (index_t step = 0; (1 << step) < groupCount; ++step) {
-        const index_t source = (2 * iGlobal + 1) << step;
-        const index_t target = iGlobal << (step + 1);
+    for (index_t step = 1; step < groupCount; step <<= 1) {
+        const index_t target = 2 * iGlobal * step;
+        const index_t source = target + step;
 
-        if (source < groupCount)
+        if (source < groupCount) {
             joinSegments(
                 sum[target], bestPrefixSum[target], bestPrefix[target],
                 sum[source], bestPrefixSum[source], bestPrefix[source]
             );
+        }
         barrier(CLK_GLOBAL_MEM_FENCE);
     }
 }

--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -1,1 +1,97 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+typedef unsigned int index_t;
+ 
+void joinSegments(
+          int *sumLeft ,       int *bestSumLeft ,       index_t *bestIndexLeft,
+    const int  sumRight, const int  bestSumRight, const index_t  bestIndexRight
+) {
+    if (*bestSumLeft +  sumRight >= bestIndexRight) { // as we reversed the array the minimal maximum sum prefix would be the rightmost one, hence >=
+        *bestSumLeft += sumRight;
+        // bestIndexLeft does not change
+    } else {
+        *bestSumLeft   = bestSumRight;
+        *bestIndexLeft = bestIndexRight;
+    }
+    *sumLeft += sumRight;
+}
+
+__kernel void max_prefix_sum(
+    __global const int *a, const index_t n,                                                    // input
+     __local int *sumLocal, __local index_t *bestPrefixLocal, __local int *bestPrefixSumLocal, // storage for results, computed within work groups 
+    __global int *sum,     __global index_t *bestPrefix,     __global int *bestPrefixSum       // storage for merging work group results
+) {                                                                                            // data is separated to distinct arrays for better cache coalescence
+    const index_t iGlobal = get_global_id(0);
+    const index_t globalSize = get_global_size(0);
+
+    const index_t iGroup = get_local_id(0);
+    const index_t groupSize = get_local_size(0);
+    const index_t groupCount = get_num_groups(0);
+    const index_t groupIndex = get_group_id(0);
+    
+    const index_t iWarp = iGroup % WARP_SIZE;
+    const index_t warpIndex = iGroup / WARP_SIZE;
+    const index_t warpCount = (groupSize + WARP_SIZE - 1) / WARP_SIZE;
+
+    // setup work group stage
+    sumLocal[iGroup] = a[globalSize - iGlobal - 1];
+    bestPrefixSumLocal[iGroup] = sumLocal[iGroup];
+    bestPrefixLocal[iGroup] = globalSize - iGlobal - 1;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // compute values inside each warp
+    for (index_t step = 0; (1 << step) < WARP_SIZE; ++step) {
+        const index_t source = (2 * iWarp + 1) << step;
+        const index_t target = iWarp << (step + 1);
+
+        if (source < groupSize)
+            joinSegments(
+                sumLocal[target], bestPrefixSumLocal[target], bestPrefixLocal[target],
+                sumLocal[source], bestPrefixSumLocal[source], bestPrefixLocal[source]
+            );
+        // no barrier needed as we are operating within a single warp
+    }
+    barrier(CLK_LOCAL_MEM_FENCE); // synchronize
+
+    return;
+
+    // join warp results pretty much the same way
+    for (index_t step = WARP_SIZE; step < warpCount * WARP_SIZE; step <<= 1) {
+        const index_t target = 2 * warpIndex * step;
+        const index_t source = target + step;
+        
+        if (source < groupSize)
+            joinSegments(
+                sumLocal[target], bestPrefixSumLocal[target], bestPrefixLocal[target],
+                sumLocal[source], bestPrefixSumLocal[source], bestPrefixLocal[source]
+            );
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    return;
+    
+    // flush results from each group to global memory
+    if (iGroup == 0) {
+        sum          [groupIndex] = sumLocal          [0];
+        bestPrefix   [groupIndex] = bestPrefixLocal   [0];
+        bestPrefixSum[groupIndex] = bestPrefixSumLocal[0];
+    }
+    barrier(CLK_GLOBAL_MEM_FENCE);
+
+    // join group results exactly the same way as before
+    for (index_t step = 0; (1 << step) < groupCount; ++step) {
+        const index_t source = (2 * iGlobal + 1) << step;
+        const index_t target = iGlobal << (step + 1);
+
+        if (source < groupCount)
+            joinSegments(
+                sum[target], bestPrefixSum[target], bestPrefix[target],
+                sum[source], bestPrefixSum[source], bestPrefix[source]
+            );
+        barrier(CLK_GLOBAL_MEM_FENCE);
+    }
+}

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -5,11 +5,12 @@
 #line 6
 
 
-__kernel void sum(__global const unsigned int *a, __local unsigned int *temp, const unsigned int n, __global volatile unsigned int *sum)
+__kernel void sum(__global const unsigned int *a, __local unsigned int *temp, const unsigned int n, __global unsigned int *sum)
 {
     const unsigned int iGlobal = get_global_id(0);
 
     const unsigned int iGroup = get_local_id(0);
+    const unsigned int groupIndex = get_group_id(0);
     const unsigned int groupSize = get_local_size(0);
     
     const unsigned int iWarp = iGroup % WARP_SIZE;
@@ -17,60 +18,28 @@ __kernel void sum(__global const unsigned int *a, __local unsigned int *temp, co
     const unsigned int warpCount = (groupSize + WARP_SIZE - 1) / WARP_SIZE;
 
     // setup
-    if (iGlobal == 0)
-        atomic_xchg(sum, 0);
-    
     temp[iGroup] = iGlobal < n ? a[iGlobal] : 0;
     barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);
     
-    // variant 1: each warp adds elements from the next one in binary tree; the last remaining warp is summed manually 
-    {
-        for (unsigned int step = WARP_SIZE; step < warpCount * WARP_SIZE; step <<= 1) {
-            const unsigned int target = 2 * warpIndex * step + iWarp;
-            if (target + step < groupSize)
-                temp[target] += temp[target + step];
+    // sum warps
+    for (unsigned int step = WARP_SIZE; step < warpCount * WARP_SIZE; step <<= 1) {
+        const unsigned int target = 2 * warpIndex * step + iWarp;
+        if (target + step < groupSize)
+            temp[target] += temp[target + step];
 
-            barrier(CLK_LOCAL_MEM_FENCE);
-        }
-
-        // variant 1.1: last warp sums itself as a binary tree
-        {
-            for (unsigned int step = 1; step < WARP_SIZE; step <<= 1) {
-                const unsigned int target = 2 * iGroup * step;
-                if (target + step < WARP_SIZE)
-                    temp[target] += temp[target + step];
-                // no barrier needed as we are operating within a single warp
-            }
-            // again, no barrier, because temp[0] will be read by a member of the same first warp
-
-            if (iGroup == 0)
-                atomic_add(sum, temp[0]);
-        }
-
-        // variant 1.2: last warp atomically adds its elements to the sum
-        // {
-        //     if (warpIndex == 0)
-        //         atomic_add(sum, temp[iWarp]);
-        // }
+        barrier(CLK_LOCAL_MEM_FENCE);
     }
 
-    // variant 2: sums are calculated within each warp and then summed using binary tree order
-    // {
-    //     for (unsigned int step = 1; step < WARP_SIZE; step <<= 1)
-    //         if (iWarp % (2 * step) == 0 && iGroup + step < groupSize)
-    //             temp[iGroup] += temp[iGroup + step];
-    //         // no barrier needed as we are operating within a single warp
-    //     barrier(CLK_LOCAL_MEM_FENCE); 
+    // sum inside the first warp
+    for (unsigned int step = 0; (step << 1) < WARP_SIZE; ++step) {
+        const unsigned int target = 2 * iGroup << step;
+        const unsigned int source = (2 * iGroup + 1) << step;
+        if (source < WARP_SIZE)
+            temp[target] += temp[source];
+        // no barrier needed as we are operating within a single warp
+    }
+    // again, no barrier, because temp[0] will be read by a member of the same first warp
 
-    //     for (unsigned int step = 1; step < warpCount; step <<= 1) {
-    //         if (warpIndex % (2 * step) == 0 && iGroup + step * WARP_SIZE < groupSize)
-    //             temp[iGroup] += temp[iGroup + step * WARP_SIZE];
-
-    //         barrier(CLK_LOCAL_MEM_FENCE);
-    //     }
-
-    //     if (iGroup == 0) {
-    //         atomic_add(sum, temp[0]);
-    //     }
-    // }
+    if (iGroup == 0)
+        sum[groupIndex] = temp[0];
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,75 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+
+__kernel void sum(__global const unsigned int *a, __local unsigned int *temp, const unsigned int n, __global unsigned int *sum)
+{
+    const unsigned int iGroup = get_local_id(0);
+    const unsigned int groupSize = get_local_size(0);
+    const unsigned int groupCount = get_num_groups(0);
+    
+    const unsigned int iWarp = iGroup % WARP_SIZE;
+    const unsigned int warpIndex = iGroup / WARP_SIZE;
+    const unsigned int warpCount = (groupSize + WARP_SIZE - 1) / WARP_SIZE;
+
+    // setup
+    if (get_global_id(0) == 0)
+        *sum = 0;
+    
+    temp[iGroup] = a[get_global_id(0)];
+    
+    barrier(CLK_LOCAL_MEM_FENCE);
+    
+    // variant 1: each warp adds elements from the next one in binary tree; the last remaining warp is summed manually 
+    {
+        for (unsigned int step = WARP_SIZE; step < warpCount * WARP_SIZE; step <<= 1) {
+            const unsigned int target = 2 * warpIndex * step + iWarp;
+            if (target + step < groupSize)
+                temp[target] += temp[target + step];
+
+            barrier(CLK_LOCAL_MEM_FENCE);
+        }
+
+        // variant 1.1: last warp sums itself as a binary tree
+        {
+            if (warpIndex == 0)
+                for (unsigned int step = 0; (1 << step) < WARP_SIZE; ++step)
+                    if (((2 * iWarp + 1) << step) < groupSize)
+                        temp[iWarp << (step + 1)] += temp[(2 * iWarp + 1) << step];
+                    // no barrier needed as we are operating within a single warp
+            // again, no barrier, because temp[0] will be read by a member of the same first warp
+
+            if (iGroup == 0)
+                atomic_add(sum, temp[0]);
+        }
+
+        // variant 1.2: last warp atomically adds its elements to the sum
+        // {
+        //     if (warpIndex == 0)
+        //         atomic_add(sum, temp[iWarp]);
+        // }
+    }
+
+    // variant 2: sums are calculated within each warp and then summed using binary tree order
+    // {
+    //     for (unsigned int step = 1; step < WARP_SIZE; step <<= 1)
+    //         if (iWarp % (2 * step) == 0 && iGroup + step < groupSize)
+    //             temp[iGroup] += temp[iGroup + step];
+    //         // no barrier needed as we are operating within a single warp
+    //     barrier(CLK_LOCAL_MEM_FENCE); 
+
+    //     for (unsigned int step = 1; step < warpCount; step <<= 1) {
+    //         if (warpIndex % (2 * step) == 0 && iGroup + step * WARP_SIZE < groupSize)
+    //             temp[iGroup] += temp[iGroup + step * WARP_SIZE];
+
+    //         barrier(CLK_LOCAL_MEM_FENCE);
+    //     }
+
+    //     if (iGroup == 0) {
+    //         atomic_add(sum, temp[0]);
+    //     }
+    // }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -108,44 +108,80 @@ int main(int argc, char **argv)
 
 //    // Раскомментируйте это:
 //
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляние на лог,
-//        // передав printLog=true - скорее всего в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float,
-//        // то это означает что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляние на лог,
+        // передав printLog=true - скорее всего в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float,
+        // то это означает что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+       
+        gpu::gpu_mem_32f results_vram;
+        results_vram.resizeN(width * height);
+
+        const unsigned int workGroupSizeX = 8;
+        const unsigned int workGroupSizeY = 4;
+        const unsigned int global_work_size_x = (width + workGroupSizeX - 1) / workGroupSizeX * workGroupSizeX;
+        const unsigned int global_work_size_y = (height + workGroupSizeY - 1) / workGroupSizeY * workGroupSizeY;
+        
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(workGroupSizeX, workGroupSizeY, global_work_size_x, global_work_size_y),
+                        results_vram,
+                        width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY,
+                        iterationsLimit, 0);
+            t.nextLap();
+        }
+
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        results_vram.readN(gpu_results.ptr(), width * height);
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+       double errorAvg = 0.0;
+       for (int j = 0; j < height; ++j) {
+           for (int i = 0; i < width; ++i) {
+               errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+           }
+       }
+       errorAvg /= width * height;
+       std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+       if (errorAvg > 0.03) {
+           throw std::runtime_error("Too high difference between CPU and GPU results!");
+       }
+    }
 
     // Это бонус ввиде интерактивной отрисовки, не забудьте запустить на ГПУ чтобы посмотреть в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    // bool useGPU = true;
+    // renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -180,8 +180,8 @@ int main(int argc, char **argv)
     // Это бонус ввиде интерактивной отрисовки, не забудьте запустить на ГПУ чтобы посмотреть в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-    bool useGPU = true;
-    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    // bool useGPU = true;
+    // renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
         results_vram.resizeN(width * height);
 
         const unsigned int workGroupSizeX = 8;
-        const unsigned int workGroupSizeY = 4;
+        const unsigned int workGroupSizeY = 8;
         const unsigned int global_work_size_x = (width + workGroupSizeX - 1) / workGroupSizeX * workGroupSizeX;
         const unsigned int global_work_size_y = (height + workGroupSizeY - 1) / workGroupSizeY * workGroupSizeY;
         
@@ -180,8 +180,8 @@ int main(int argc, char **argv)
     // Это бонус ввиде интерактивной отрисовки, не забудьте запустить на ГПУ чтобы посмотреть в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-    // bool useGPU = true;
-    // renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    bool useGPU = true;
+    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }
@@ -208,6 +208,7 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
         results_vram.resizeN(width * height);
     }
 
+    timer t;
     do {
         if (!useGPU) {
             mandelbrotCPU(results.ptr(), width, height,
@@ -249,7 +250,9 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
         }
         sizeX /= zoomingSpeed;
         sizeY /= zoomingSpeed;
+        t.nextLap();
     } while (!window.isClosed());
+    std::cout << "Frame time: " << t.lapAvg() << "+-" << t.lapStd() << " s => ~" << 1 / t.lapAvg() << " FPS"  << std::endl;
 }
 
 

--- a/src/main_max_prefix_sum.cpp
+++ b/src/main_max_prefix_sum.cpp
@@ -20,7 +20,7 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 int main(int argc, char **argv)
 {
     int benchmarkingIters = 10;
-    int max_n = (1 << 24);
+    int max_n = (1 << 26);
 
     for (int n = 2; n <= max_n; n *= 2) {
         std::cout << "______________________________________________" << std::endl;
@@ -31,8 +31,6 @@ int main(int argc, char **argv)
         FastRandom r(n);
         for (int i = 0; i < n; ++i) {
             as[i] = (unsigned int) r.next(-values_range, values_range);
-            if (n < 32)
-                std::cout << (i > 0 ? ", " : "") << as[i];
         }
         if (n < 32)
             std::cout << std::endl;
@@ -83,38 +81,56 @@ int main(int argc, char **argv)
             context.init(device.device_id_opencl);
             context.activate();
 
-            ocl::Kernel kernel(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "max_prefix_sum");
+            ocl::Kernel setupKernel(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "setup");
+            ocl::Kernel stepKernel(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "max_prefix_sum_step");
             bool printLog = false;
-            kernel.compile(printLog);
+            setupKernel.compile(printLog);
+            stepKernel.compile(printLog);
         
             const unsigned int workGroupSize = 256;
-            const unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            const unsigned int workGroupCount = global_work_size / workGroupSize;
-            std::vector<int> max_sum(workGroupCount);
-            std::vector<unsigned int> result(workGroupCount);
                 
             auto input_data_vram = gpu::gpu_mem_32i::createN(n);
             input_data_vram.writeN(as.data(), n);
         
-            auto sum_vram = gpu::gpu_mem_32i::createN(workGroupCount);
-            auto best_index_vram = gpu::gpu_mem_32u::createN(workGroupCount);
-            auto best_sum_vram = gpu::gpu_mem_32i::createN(workGroupCount);
+            gpu::gpu_mem_32i sum_vram[] = {
+                gpu::gpu_mem_32i::createN(n),
+                gpu::gpu_mem_32i::createN(n)
+            };
+            gpu::gpu_mem_32u best_index_vram[] = {
+                gpu::gpu_mem_32u::createN(n),
+                gpu::gpu_mem_32u::createN(n)
+            };
+            gpu::gpu_mem_32i best_sum_vram[] = {
+                gpu::gpu_mem_32i::createN(n),
+                gpu::gpu_mem_32i::createN(n)
+            };
             
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                kernel.exec(
-                    gpu::WorkSize(workGroupSize, global_work_size), 
+                setupKernel.exec(
+                    gpu::WorkSize(workGroupSize, n), 
                     input_data_vram, n,
-                    ocl::LocalMem(workGroupSize * sizeof(int)), ocl::LocalMem(workGroupSize * sizeof(unsigned int)), ocl::LocalMem(workGroupSize * sizeof(int)), 
-                    sum_vram,                                   best_index_vram,                                     best_sum_vram
+                    sum_vram[0], best_index_vram[0], best_sum_vram[0]
                 );
-                best_index_vram.readN(result.data(), workGroupCount);
-                best_sum_vram  .readN(max_sum.data(), workGroupCount);
-                for (size_t i = 0; i < workGroupCount; ++i) {
-                    std::cout << max_sum[i] << " @ " << result[i] << (i + 1 < workGroupCount ? ", " : "\n");
+                
+                unsigned int step = 0;
+                for (unsigned int currentWorkSize = n; currentWorkSize > 1; currentWorkSize = (currentWorkSize + workGroupSize - 1) / workGroupSize, step ^= 1) {
+                    stepKernel.exec(
+                        gpu::WorkSize(workGroupSize, currentWorkSize), currentWorkSize, 
+                        sum_vram[step],                             best_index_vram[step],                               best_sum_vram[step],
+                        ocl::LocalMem(workGroupSize * sizeof(int)), ocl::LocalMem(workGroupSize * sizeof(unsigned int)), ocl::LocalMem(workGroupSize * sizeof(int)), 
+                        sum_vram[step ^ 1],                         best_index_vram[step ^ 1],                           best_sum_vram[step ^ 1]
+                    );
                 }
-                EXPECT_THE_SAME(reference_result, result[0], "GPU result should be consistent!");
-                EXPECT_THE_SAME(reference_max_sum, max_sum[0], "GPU result should be consistent!");
+                
+                int max_sum;
+                best_sum_vram[step].readN(&max_sum, 1);
+                
+                unsigned int result;
+                best_index_vram[step].readN(&result, 1);
+                
+                EXPECT_THE_SAME(reference_result, result, "GPU result should be consistent!");
+                EXPECT_THE_SAME(reference_max_sum, max_sum, "GPU result should be consistent!");
                 t.nextLap();
             }
             std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;

--- a/src/main_max_prefix_sum.cpp
+++ b/src/main_max_prefix_sum.cpp
@@ -1,7 +1,10 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
 
+#include "cl/max_prefix_sum_cl.h"
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
@@ -13,7 +16,6 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
-
 
 int main(int argc, char **argv)
 {
@@ -32,11 +34,11 @@ int main(int argc, char **argv)
         }
 
         int reference_max_sum;
-        int reference_result;
+        unsigned int reference_result;
         {
             int max_sum = 0;
             int sum = 0;
-            int result = 0;
+            unsigned int result = 0;
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
                 if (sum > max_sum) {
@@ -54,7 +56,7 @@ int main(int argc, char **argv)
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
                 int max_sum = 0;
                 int sum = 0;
-                int result = 0;
+                unsigned int result = 0;
                 for (int i = 0; i < n; ++i) {
                     sum += as[i];
                     if (sum > max_sum) {
@@ -71,7 +73,46 @@ int main(int argc, char **argv)
         }
 
         {
-            // TODO: implement on OpenCL
+            gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+            gpu::Context context;
+            context.init(device.device_id_opencl);
+            context.activate();
+
+            ocl::Kernel kernel(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "max_prefix_sum");
+            bool printLog = false;
+            kernel.compile(printLog);
+        
+            const unsigned int workGroupSize = 256;
+            const unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+            const unsigned int workGroupCount = global_work_size / workGroupSize;
+            int max_sum;
+            unsigned int result;
+                
+            auto input_data_vram = gpu::gpu_mem_32i::createN(global_work_size);
+            as.resize(global_work_size, 0);
+            input_data_vram.writeN(as.data(), global_work_size);
+        
+            auto sum_vram = gpu::gpu_mem_32i::createN(workGroupCount);
+            auto best_index_vram = gpu::gpu_mem_32u::createN(workGroupCount);
+            auto best_sum_vram = gpu::gpu_mem_32i::createN(workGroupCount);
+            
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                kernel.exec(
+                    gpu::WorkSize(workGroupSize, global_work_size), 
+                    input_data_vram, n,
+                    ocl::LocalMem(workGroupSize * sizeof(int)), ocl::LocalMem(workGroupSize * sizeof(unsigned int)), ocl::LocalMem(workGroupSize * sizeof(int)), 
+                    sum_vram,                                   best_index_vram,                                     best_sum_vram
+                );
+                best_index_vram.readN(&result , 1);
+                best_sum_vram  .readN(&max_sum, 1);
+                EXPECT_THE_SAME(reference_max_sum, max_sum, "GPU result should be consistent!");
+                EXPECT_THE_SAME(reference_result, result, "GPU result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
         }
     }
 }

--- a/src/main_max_prefix_sum.cpp
+++ b/src/main_max_prefix_sum.cpp
@@ -31,15 +31,19 @@ int main(int argc, char **argv)
         FastRandom r(n);
         for (int i = 0; i < n; ++i) {
             as[i] = (unsigned int) r.next(-values_range, values_range);
+            if (n < 32)
+                std::cout << (i > 0 ? ", " : "") << as[i];
         }
+        if (n < 32)
+            std::cout << std::endl;
 
         int reference_max_sum;
         unsigned int reference_result;
         {
-            int max_sum = 0;
-            int sum = 0;
-            unsigned int result = 0;
-            for (int i = 0; i < n; ++i) {
+            int max_sum = as[0];
+            int sum = as[0];
+            unsigned int result = 1;
+            for (int i = 1; i < n; ++i) {
                 sum += as[i];
                 if (sum > max_sum) {
                     max_sum = sum;
@@ -54,10 +58,10 @@ int main(int argc, char **argv)
         {
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                int max_sum = 0;
-                int sum = 0;
-                unsigned int result = 0;
-                for (int i = 0; i < n; ++i) {
+                int max_sum = as[0];
+                int sum = as[0];
+                unsigned int result = 1;
+                for (int i = 1; i < n; ++i) {
                     sum += as[i];
                     if (sum > max_sum) {
                         max_sum = sum;
@@ -86,12 +90,11 @@ int main(int argc, char **argv)
             const unsigned int workGroupSize = 256;
             const unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
             const unsigned int workGroupCount = global_work_size / workGroupSize;
-            int max_sum;
-            unsigned int result;
+            std::vector<int> max_sum(workGroupCount);
+            std::vector<unsigned int> result(workGroupCount);
                 
-            auto input_data_vram = gpu::gpu_mem_32i::createN(global_work_size);
-            as.resize(global_work_size, 0);
-            input_data_vram.writeN(as.data(), global_work_size);
+            auto input_data_vram = gpu::gpu_mem_32i::createN(n);
+            input_data_vram.writeN(as.data(), n);
         
             auto sum_vram = gpu::gpu_mem_32i::createN(workGroupCount);
             auto best_index_vram = gpu::gpu_mem_32u::createN(workGroupCount);
@@ -105,10 +108,13 @@ int main(int argc, char **argv)
                     ocl::LocalMem(workGroupSize * sizeof(int)), ocl::LocalMem(workGroupSize * sizeof(unsigned int)), ocl::LocalMem(workGroupSize * sizeof(int)), 
                     sum_vram,                                   best_index_vram,                                     best_sum_vram
                 );
-                best_index_vram.readN(&result , 1);
-                best_sum_vram  .readN(&max_sum, 1);
-                EXPECT_THE_SAME(reference_max_sum, max_sum, "GPU result should be consistent!");
-                EXPECT_THE_SAME(reference_result, result, "GPU result should be consistent!");
+                best_index_vram.readN(result.data(), workGroupCount);
+                best_sum_vram  .readN(max_sum.data(), workGroupCount);
+                for (size_t i = 0; i < workGroupCount; ++i) {
+                    std::cout << max_sum[i] << " @ " << result[i] << (i + 1 < workGroupCount ? ", " : "\n");
+                }
+                EXPECT_THE_SAME(reference_result, result[0], "GPU result should be consistent!");
+                EXPECT_THE_SAME(reference_max_sum, max_sum[0], "GPU result should be consistent!");
                 t.nextLap();
             }
             std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -76,8 +76,7 @@ int main(int argc, char **argv)
         unsigned int sum;
             
         gpu::gpu_mem_32u input_data_vram = gpu::gpu_mem_32u::createN(global_work_size);
-        as.resize(global_work_size, 0);
-        input_data_vram.writeN(as.data(), global_work_size);
+        input_data_vram.writeN(as.data(), n);
        
         gpu::gpu_mem_32u sum_vram;
         sum_vram.resizeN(1);

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,7 +1,10 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
 
+#include "cl/sum_cl.h"
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
@@ -58,7 +61,35 @@ int main(int argc, char **argv)
     }
 
     {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum");
+        bool printLog = false;
+        kernel.compile(printLog);
+       
+        const unsigned int workGroupSize = 256;
+        const unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+        unsigned int sum;
+            
+        gpu::gpu_mem_32u input_data_vram = gpu::gpu_mem_32u::createN(global_work_size);
+        as.resize(global_work_size, 0);
+        input_data_vram.writeN(as.data(), global_work_size);
+       
+        gpu::gpu_mem_32u sum_vram;
+        sum_vram.resizeN(1);
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            kernel.exec(gpu::WorkSize(workGroupSize, global_work_size), input_data_vram, ocl::LocalMem(workGroupSize * sizeof(unsigned int)), n, sum_vram);
+            sum_vram.readN(&sum, 1);
+            EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 }


### PR DESCRIPTION
1. Пытался для ускорения сглаживания переиспользовать уже посчитанные соседние значения, но там получались какие-то чёрные полосы

P.S. по итогам выполнения задания 3 к 1 появилось соображение, что посчитанный результат использовать не получалось как раз из-за локальности барьеров
```
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1672/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1672/1740 Mb
CPU: 0.529642+-0.00176089 s
CPU: 18.8807 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.0133188+-4.07039e-05 s
GPU: 750.817 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0%
Frame time: 0.0801853+-0.00398727 s => ~12.4711 FPS
```
2. За счёт того, что задание простое, легко пробовать разные подходы и смотреть, что работает быстрее. Мне понравилось)
```
CPU:     0.236352+-0.00674291 s
CPU:     423.097 millions/s
CPU OMP: 0.0377012+-0.000151991 s
CPU OMP: 2652.44 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1672/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1672/1740 Mb
GPU: 0.0140465+-0.000221492 s
GPU: 7119.21 millions/s
```
3. Тут я наткнулся на неожиданный подвох, что барьеры работают в пределах рабочих групп (почему-то был уверен, что глобально, хотя бы если CLK_GLOBAL_MEM_FENCE) -- к этому моменту я уже несколько вечеров пытался разобраться, почему у меня возникают расхождения на массивах размера >=8k. В итоге ничего лучше разбиения на несколько вызовов ядра я не придумал
А ещё в подсчёте сумм на процессоре был небольшой баг: там как начальный вариант брался 0, что могло дать неправильный ответ, если все элементы отрицательные
```
______________________________________________
n=2 values in range: [-1023; 1023]

Max prefix sum: -517 on prefix [0; 2)
CPU: 2e-06+-0 s
CPU: 1 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1672/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1672/1740 Mb
GPU: 0.00373183+-0.000212892 s
GPU: 0.00053593 millions/s
______________________________________________
n=4 values in range: [-1023; 1023]

Max prefix sum: 1014 on prefix [0; 2)
CPU: 2e-06+-0 s
CPU: 2 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.00357433+-0.00023906 s
GPU: 0.00111909 millions/s
______________________________________________
n=8 values in range: [-1023; 1023]

Max prefix sum: -887 on prefix [0; 1)
CPU: 2e-06+-0 s
CPU: 4 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.0035975+-0.000306454 s
GPU: 0.00222377 millions/s
______________________________________________
n=16 values in range: [-1023; 1023]

Max prefix sum: 457 on prefix [0; 1)
CPU: 2.33333e-06+-4.71405e-07 s
CPU: 6.85714 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.0038325+-0.000285978 s
GPU: 0.00417482 millions/s
______________________________________________
n=32 values in range: [-1023; 1023]
Max prefix sum: -51 on prefix [0; 1)
CPU: 2.16667e-06+-3.72678e-07 s
CPU: 14.7692 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.00358817+-0.000251557 s
GPU: 0.0089182 millions/s
______________________________________________
n=64 values in range: [-1023; 1023]
Max prefix sum: 1170 on prefix [0; 17)
CPU: 2.66667e-06+-4.71405e-07 s
CPU: 24 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.0038015+-0.000309141 s
GPU: 0.0168355 millions/s
______________________________________________
n=128 values in range: [-1023; 1023]
Max prefix sum: 4773 on prefix [0; 124)
CPU: 3e-06+-0 s
CPU: 42.6667 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.0034085+-0.000274626 s
GPU: 0.0375532 millions/s
______________________________________________
n=256 values in range: [-1023; 1023]
Max prefix sum: 7649 on prefix [0; 183)
CPU: 3.83333e-06+-3.72678e-07 s
CPU: 66.7826 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.00341633+-0.00023526 s
GPU: 0.0749341 millions/s
______________________________________________
n=512 values in range: [-1023; 1023]
Max prefix sum: 4170 on prefix [0; 52)
CPU: 6e-06+-0 s
CPU: 85.3333 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.0047505+-0.000204231 s
GPU: 0.107778 millions/s
______________________________________________
n=1024 values in range: [-1023; 1023]
Max prefix sum: 14708 on prefix [0; 829)
CPU: 9e-06+-1.13687e-13 s
CPU: 113.778 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.004999+-0.000280693 s
GPU: 0.204841 millions/s
______________________________________________
n=2048 values in range: [-1023; 1023]
Max prefix sum: 22303 on prefix [0; 1779)
CPU: 1.63333e-05+-4.71405e-07 s
CPU: 125.388 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.00515333+-0.000489846 s
GPU: 0.397413 millions/s
______________________________________________
n=4096 values in range: [-1023; 1023]
Max prefix sum: 4292 on prefix [0; 58)
CPU: 1.76667e-05+-1.10554e-06 s
CPU: 231.849 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.00546683+-0.000487985 s
GPU: 0.749245 millions/s
______________________________________________
n=8192 values in range: [-1023; 1023]
Max prefix sum: 3297 on prefix [0; 470)
CPU: 5.8e-05+-0 s
CPU: 141.241 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.00469933+-0.000390669 s
GPU: 1.74323 millions/s
______________________________________________
n=16384 values in range: [-1023; 1023]
Max prefix sum: 103982 on prefix [0; 10101)
CPU: 7.03333e-05+-7.52034e-06 s
CPU: 232.948 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.00607633+-0.000130882 s
GPU: 2.69636 millions/s
______________________________________________
n=32768 values in range: [-1023; 1023]
Max prefix sum: 75785 on prefix [0; 2074)
CPU: 0.000128833+-3.72678e-07 s
CPU: 254.344 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.0045515+-0.000539482 s
GPU: 7.19938 millions/s
______________________________________________
n=65536 values in range: [-1023; 1023]
Max prefix sum: 93500 on prefix [0; 61715)
CPU: 0.000255667+-7.45356e-07 s
CPU: 256.334 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.00580917+-0.000179731 s
GPU: 11.2815 millions/s
______________________________________________
n=131072 values in range: [-1023; 1023]
Max prefix sum: 310443 on prefix [0; 102163)
CPU: 0.000917167+-4.84481e-06 s
CPU: 142.91 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.006941+-0.000528535 s
GPU: 18.8837 millions/s
______________________________________________
n=262144 values in range: [-1023; 1023]
Max prefix sum: 449686 on prefix [0; 211310)
CPU: 0.0018315+-6.44851e-06 s
CPU: 143.131 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.0061515+-0.000508789 s
GPU: 42.6146 millions/s
______________________________________________
n=524288 values in range: [-1023; 1023]
Max prefix sum: 18511 on prefix [0; 470827)
CPU: 0.00202467+-6.01849e-06 s
CPU: 258.95 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.0061725+-0.000290678 s
GPU: 84.9393 millions/s
______________________________________________
n=1048576 values in range: [-1023; 1023]
Max prefix sum: 46638 on prefix [0; 12341)
CPU: 0.00404617+-8.15305e-06 s
CPU: 259.153 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.006877+-0.000445232 s
GPU: 152.476 millions/s
______________________________________________
n=2097152 values in range: [-1023; 1023]
Max prefix sum: 1199401 on prefix [0; 1691780)
CPU: 0.00812833+-9.26763e-06 s
CPU: 258.005 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.008433+-0.000333591 s
GPU: 248.684 millions/s
______________________________________________
n=4194304 values in range: [-511; 511]
Max prefix sum: 43576 on prefix [0; 3543860)
CPU: 0.0162173+-1.00775e-05 s
CPU: 258.631 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.0107052+-0.000576166 s
GPU: 391.802 millions/s
______________________________________________
n=8388608 values in range: [-255; 255]
Max prefix sum: 262168 on prefix [0; 2631415)
CPU: 0.03239+-1.40119e-05 s
CPU: 258.988 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.0140665+-0.000835756 s
GPU: 596.354 millions/s
______________________________________________
n=16777216 values in range: [-127; 127]
Max prefix sum: 79474 on prefix [0; 976207)
CPU: 0.064611+-3.16596e-05 s
CPU: 259.665 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.022516+-0.000252816 s
GPU: 745.124 millions/s
______________________________________________
n=33554432 values in range: [-63; 63]
Max prefix sum: 107525 on prefix [0; 14856473)
CPU: 0.145832+-0.000495723 s
CPU: 230.09 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.0394805+-0.000524018 s
GPU: 849.899 millions/s
______________________________________________
n=67108864 values in range: [-31; 31]
Max prefix sum: 146120 on prefix [0; 49556834)
CPU: 0.290888+-0.000428003 s
CPU: 230.704 millions/s
OpenCL devices:
  Device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
Using device #0: GPU. Unknown AMD GPU (gfx902). Free memory: 1671/1740 Mb
GPU: 0.071711+-0.000347972 s
GPU: 935.824 millions/s
```