### PR TITLE
Task03 Николай Смирнов CSC

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,46 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float *results,
+                         unsigned int width, unsigned int height,
+                         float fromX, float fromY,
+                         float sizeX, float sizeY,
+                         unsigned int iters)
 {
+    
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+    
     // TODO если хочется избавиться от зернистости и дрожжания при интерактивном погружении - добавьте anti-aliasing:
     // грубо говоря при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+    
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+    
+    float x = x0;
+    float y = y0;
+    
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+    
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
+    
+    //printf("%d %d\n", a, b);
 }

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -8,16 +8,10 @@ __kernel void mandelbrot(__global float *results,
                          unsigned int width, unsigned int height,
                          float fromX, float fromY,
                          float sizeX, float sizeY,
-                         unsigned int iters)
+                         unsigned int iters, int smoothing)
 {
-    
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
-    
-    // TODO если хочется избавиться от зернистости и дрожжания при интерактивном погружении - добавьте anti-aliasing:
-    // грубо говоря при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
-    // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
-    // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
     
     int i = get_global_id(0);
     int j = get_global_id(1);
@@ -44,6 +38,4 @@ __kernel void mandelbrot(__global float *results,
     
     result = 1.0f * result / iters;
     results[j * width + i] = result;
-    
-    //printf("%d %d\n", a, b);
 }

--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -1,1 +1,83 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+
+/*
+__kernel void max_prefix_sum_tree(__global int *inout_sum, __global int *inout_prefix,  unsigned int n)
+{
+    __local int max_prefix[2][WORK_GROUP_SIZE];
+    __local int sum[2][WORK_GROUP_SIZE];
+
+    int id = get_global_id(0);
+    int local_id = get_local_id(0);
+    
+    sum[0][local_id] = inout_sum[id];
+    max_prefix[0][local_id] = inout_prefix[id];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int i = WORK_GROUP_SIZE / 2; i >= 1; i /= 2) {
+        if (local_id < i) {
+            int id1 = local_id * 2;
+            int id2 = local_id * 2 + 1;
+    
+            int s1 = sumA[id1];
+            int s2 = sumA[id2];
+    
+            sumB[local_id] = s1 + s2;
+            max_prefixB[local_id] = max(max_prefixA[id1], s1 + max_prefixA[id2]);
+        }
+        
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    
+    if (local_id == 0) {
+        int out_id = id / WORK_GROUP_SIZE;
+        inout_sum[out_id] = sumA[0];
+        inout_prefix[out_id] = max_prefixA[0];
+    }
+}*/
+
+
+__kernel void max_prefix_sum(__global int *in_sum, __global int *in_prefix, __global int *in_pid,
+                             __global int *out_sum, __global int *out_prefix, __global int *out_pid,
+                             unsigned int n)
+{
+    __local int max_prefix[WORK_GROUP_SIZE];
+    __local int sum[WORK_GROUP_SIZE];
+    __local int pid[WORK_GROUP_SIZE];
+    
+    int id = get_global_id(0);
+    int local_id = get_local_id(0);
+    
+    sum[local_id] = in_sum[id];
+    max_prefix[local_id] = in_prefix[id];
+    pid[local_id] = in_pid[id];
+    
+    barrier(CLK_LOCAL_MEM_FENCE);
+    
+    if (local_id == 0) {
+        int mySum = 0;
+        int myPref = 0;
+        int myPid = 0;
+        
+        for (int i = 0; i < min((int) WORK_GROUP_SIZE, (int) (n - id)); i++) {
+            if (myPref < mySum + max_prefix[i]) {
+                myPref = mySum + max_prefix[i];
+                myPid = pid[i];
+            }
+            
+            //myPref = max((int) (myPref), (int) (mySum + max_prefix[i]));
+            mySum += sum[i];
+        }
+        
+        int out_id = id / WORK_GROUP_SIZE;
+        
+        out_sum[out_id] = mySum;
+        out_prefix[out_id] = myPref;
+        out_pid[out_id] = myPid;
+    }
+}

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,55 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void sum_naive(__global const unsigned int *as, __global unsigned int *res, unsigned int n)
+{
+    const int work_group_size = get_local_size(0);
+    __local int A[WORK_GROUP_SIZE];
+    
+    int id = get_global_id(0);
+    int local_id = get_local_id(0);
+    
+    A[local_id] = as[id];
+    
+    barrier(CLK_LOCAL_MEM_FENCE);
+    
+    if (local_id == 0) {
+        unsigned int s = 0;
+        for (int i = 0; i < work_group_size; ++i) {
+            s += A[i];
+        }
+    
+        atomic_add(res, s);
+    }
+}
+
+
+__kernel void sum_tree(__global const unsigned int *as, __global unsigned int *res, unsigned int n)
+{
+    const int work_group_size = get_local_size(0);
+    __local int A[WORK_GROUP_SIZE];
+    __local int B[WORK_GROUP_SIZE];
+    
+    int id = get_global_id(0);
+    int local_id = get_local_id(0);
+    
+    A[local_id] = as[id];
+    
+    barrier(CLK_LOCAL_MEM_FENCE);
+    
+    for (int gap = WORK_GROUP_SIZE; gap > 1; gap /= 2) {
+        if (2 * local_id < gap) {
+            int a = A[local_id];
+            int b = A[local_id + gap / 2];
+            A[local_id] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    
+    if (local_id == 0) {
+        atomic_add(res, A[0]);
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -131,7 +131,7 @@ int main(int argc, char **argv)
                         res_buffer, width, height,
                         centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
                         sizeX, sizeY,
-                        iterationsLimit);
+                        iterationsLimit, 0);
             
             t.nextLap();
         }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,40 +106,73 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляние на лог,
-//        // передав printLog=true - скорее всего в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float,
-//        // то это означает что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        gpu::gpu_mem_32f res_buffer;
+        res_buffer.resizeN(width * height);
+        
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляние на лог,
+        // передав printLog=true - скорее всего в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float,
+        // то это означает что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(16, 16, width, height),
+                        res_buffer, width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY,
+                        iterationsLimit);
+            
+            t.nextLap();
+        }
+        
+        res_buffer.readN(gpu_results.ptr(), width * height);
+        
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+    
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+        
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+        
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+    
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус ввиде интерактивной отрисовки, не забудьте запустить на ГПУ чтобы посмотреть в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс

--- a/src/main_max_prefix_sum.cpp
+++ b/src/main_max_prefix_sum.cpp
@@ -1,6 +1,9 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+#include "cl/max_prefix_sum_cl.h"
 
 
 template<typename T>
@@ -17,6 +20,17 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 int main(int argc, char **argv)
 {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    
+    const unsigned int workGroupSize = 256;
+    std::string defines = "-DWORK_GROUP_SIZE=" + std::to_string(workGroupSize);
+    ocl::Kernel kernel(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "max_prefix_sum", defines);
+    kernel.compile(false);
+    
     int benchmarkingIters = 10;
     int max_n = (1 << 24);
 
@@ -28,7 +42,7 @@ int main(int argc, char **argv)
         std::vector<int> as(n, 0);
         FastRandom r(n);
         for (int i = 0; i < n; ++i) {
-            as[i] = (unsigned int) r.next(-values_range, values_range);
+            as[i] = (unsigned int) r.next(-values_range, values_range); // ?? confusing cast from (int) to (unsigned int) and then back to (int)
         }
 
         int reference_max_sum;
@@ -71,7 +85,68 @@ int main(int argc, char **argv)
         }
 
         {
-            // TODO: implement on OpenCL
+            //unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+            unsigned int global_work_size = n;
+    
+            int out_sum;
+            int out_prefix;
+            int out_pid;
+            
+            gpu::gpu_mem_32i in_sum_buf, in_prefix_buf, in_pid_buf;
+            gpu::gpu_mem_32i out_sum_buf, out_prefix_buf, out_pid_buf;
+            
+            in_sum_buf.resizeN(global_work_size);
+            in_prefix_buf.resizeN(global_work_size);
+            in_pid_buf.resizeN(global_work_size);
+            
+            out_sum_buf.resizeN((global_work_size + workGroupSize - 1) / workGroupSize);
+            out_prefix_buf.resizeN((global_work_size + workGroupSize - 1) / workGroupSize);
+            out_pid_buf.resizeN((global_work_size + workGroupSize - 1) / workGroupSize);
+    
+            std::vector<int> range(global_work_size);
+            for (int i = 0; i < global_work_size; i++) range[i] = i + 1;
+    
+            
+            
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; iter++) {
+                in_sum_buf.writeN(as.data(), global_work_size);
+                in_prefix_buf.writeN(as.data(), global_work_size);
+                in_pid_buf.writeN(range.data(), global_work_size);
+                
+                gpu::gpu_mem_32i * p_in_sum = &in_sum_buf;
+                gpu::gpu_mem_32i * p_out_sum = &out_sum_buf;
+                
+                gpu::gpu_mem_32i * p_in_pref = &in_prefix_buf;
+                gpu::gpu_mem_32i * p_out_pref = &out_prefix_buf;
+                
+                gpu::gpu_mem_32i * p_in_pid = &in_pid_buf;
+                gpu::gpu_mem_32i * p_out_pid = &out_pid_buf;
+                
+                for (unsigned int i = global_work_size; i > 1; i = (i + workGroupSize - 1) / workGroupSize)
+                {
+                    kernel.exec(gpu::WorkSize(workGroupSize, i),
+                                *p_in_sum, *p_in_pref, *p_in_pid,
+                                *p_out_sum, *p_out_pref, *p_out_pid,
+                                i);
+                    
+                    unsigned int out_size = (i + workGroupSize - 1) / workGroupSize;
+                    
+                    std::swap(p_in_sum, p_out_sum);
+                    std::swap(p_in_pref, p_out_pref);
+                    std::swap(p_in_pid, p_out_pid);
+                }
+                
+                p_in_pid->readN(&out_pid, 1);
+                p_in_pref->readN(&out_prefix, 1);
+                
+                EXPECT_THE_SAME(reference_max_sum, out_prefix, "GPU result should be consistent!");
+                EXPECT_THE_SAME(reference_result, out_pid, "GPU result should be consistent!");
+                t.nextLap();
+            }
+    
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
         }
     }
 }

--- a/src/main_max_prefix_sum.cpp
+++ b/src/main_max_prefix_sum.cpp
@@ -106,13 +106,19 @@ int main(int argc, char **argv)
             std::vector<int> range(global_work_size);
             for (int i = 0; i < global_work_size; i++) range[i] = i + 1;
     
-            
-            
-            timer t;
-            for (int iter = 0; iter < benchmarkingIters; iter++) {
+            if (benchmarkingIters == 1) {
                 in_sum_buf.writeN(as.data(), global_work_size);
                 in_prefix_buf.writeN(as.data(), global_work_size);
                 in_pid_buf.writeN(range.data(), global_work_size);
+            }
+            
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; iter++) {
+                if (benchmarkingIters != 1) {
+                    in_sum_buf.writeN(as.data(), global_work_size);
+                    in_prefix_buf.writeN(as.data(), global_work_size);
+                    in_pid_buf.writeN(range.data(), global_work_size);
+                }
                 
                 gpu::gpu_mem_32i * p_in_sum = &in_sum_buf;
                 gpu::gpu_mem_32i * p_out_sum = &out_sum_buf;


### PR DESCRIPTION
## Задание 3.1. Фрактал Мандельброта
```
OpenCL devices:
  Device #0: CPU.         Intel(R) Core(TM) i5-3570 CPU @ 3.40GHz. Intel(R) Corporation. Total memory: 8175 Mb
  Device #1: GPU. GeForce GTX 1060 3GB. Total memory: 3072 Mb
Using device #1: GPU. GeForce GTX 1060 3GB. Total memory: 3072 Mb
CPU: 1.23767+-0.0254143 s
CPU: 8.07972 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.008+-0 s
GPU: 1250 GFlops
    Real iterations fraction: 56.0919%
GPU vs CPU average results difference: 1.0902%
```

## Задание 3.2. Суммирование чисел
Сделал два кернела. В кернеле `sum_naive` первый поток суммирует всю рабочую группу и делает atomic_add. В кернеле `sum_tree` сумма считается бинарным деревом. Почему-то второй способ не быстрее первого, хотя больше потоков выполняют работу (возможно из-за барьера на каждом уровне?).
```
CPU:     0.311333+-0.000471405 s
CPU:     321.199 millions/s
CPU OMP: 0.0895+-0.00138444 s
CPU OMP: 1117.32 millions/s
OpenCL devices:
  Device #0: CPU.         Intel(R) Core(TM) i5-3570 CPU @ 3.40GHz. Intel(R) Corporation. Total memory: 8175 Mb
  Device #1: GPU. GeForce GTX 1060 3GB. Total memory: 3072 Mb
Using device #1: GPU. GeForce GTX 1060 3GB. Total memory: 3072 Mb
GPU naive: 0.009+-1.16415e-10 s
GPU naive: 11111.1 millions/s
GPU tree: 0.00966667+-0.000745356 s
GPU tree: 10344.8 millions/s
```