### PR TITLE
Task03 Aleksandr Eslikov CSC

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,42 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float* results,
+                         unsigned int width,
+                         unsigned int height,
+                         float fromX,
+                         float fromY,
+                         float sizeX,
+                         float sizeY,
+                         unsigned int iters)
 {
-    // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
-    // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
+    // TODO если хочется избавиться от зернистости и дрожжания при интерактивном погружении - добавьте anti-aliasing:
+    // грубо говоря при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    unsigned int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+
+    float result = 1.0f * iter / iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -1,1 +1,31 @@
-// TODO
+#define WG_SIZE 32
+
+__kernel void sum(__global int* as,
+                  __global int* result,
+                  __global int* maxPrefixPerGroup,
+                  __global int* maxPrefixPerGroupIndex)
+{
+    __local int groupLine[WG_SIZE];
+    groupLine[get_local_id(0)] = as[get_global_id(0)];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if(get_local_id(0) == 0) {
+        int ac = 0;
+        int maxPrefix = 0;
+        int maxIndex = 0;
+        int groupSize = get_local_size(0);
+        for(int i = 0; i < groupSize; i++) {
+            int element = groupLine[i];
+            int elementIndex = get_group_id(0) * get_local_size(0) + i;
+
+            ac += element;
+            if (ac > maxPrefix) {
+                maxPrefix = ac;
+                maxIndex = elementIndex;
+            }
+        }
+        result[get_group_id(0)] = ac;
+        maxPrefixPerGroup[get_group_id(0)] = maxPrefix;
+        maxPrefixPerGroupIndex[get_group_id(0)] = maxIndex;
+    }
+}

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,32 @@
-// TODO
+#define WG_SIZE 32
+
+__kernel void sum(__global unsigned int* as,
+                  __global unsigned int* result)
+{
+    __local unsigned int lineToSum[WG_SIZE + WG_SIZE];
+    __local unsigned int lineSum[WG_SIZE];
+
+    int groupDataIndex = get_group_id(0) * 2 * get_local_size(0);
+
+    int elementAIdx = get_local_id(0);
+    int elementBIdx = get_local_id(0) + get_local_size(0);
+
+    int itemAToAddIdx = groupDataIndex + elementAIdx;
+    int itemBToAddIdx = groupDataIndex + elementBIdx;
+
+    lineToSum[elementAIdx] = as[itemAToAddIdx];
+    lineToSum[elementBIdx] = as[itemBToAddIdx];
+
+    lineSum[elementAIdx] = lineToSum[elementAIdx] + lineToSum[elementBIdx];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if(get_local_id(0) == 0) {
+        unsigned int ac = 0;
+        unsigned int groupSize = get_local_size(0);
+        for(unsigned int i = 0; i < groupSize; i++) {
+            ac += lineSum[i];
+        }
+        result[get_group_id(0)] = ac;
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -8,7 +8,6 @@
 
 #include "cl/mandelbrot_cl.h"
 
-
 void mandelbrotCPU(float* results,
                    unsigned int width, unsigned int height,
                    float fromX, float fromY,
@@ -62,14 +61,14 @@ int main(int argc, char **argv)
     unsigned int height = 2048;
     unsigned int iterationsLimit = 256;
 
-    float centralX = -0.789136f;
-    float centralY = -0.150316f;
-    float sizeX = 0.00239f;
+//    float centralX = -0.789136f;
+//    float centralY = -0.150316f;
+//    float sizeX = 0.00239f;
 
 //    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
-//    float centralX = -0.5f;
-//    float centralY = 0.0f;
-//    float sizeX = 2.0f;
+    float centralX = -0.5f;
+    float centralY = 0.0f;
+    float sizeX = 2.0f;
 
     images::Image<float> cpu_results(width, height, 1);
     images::Image<float> gpu_results(width, height, 1);
@@ -89,7 +88,7 @@ int main(int argc, char **argv)
         }
         size_t flopsInLoop = 10;
         size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
+        size_t gflops = pow(10, 9);//1000*1000*1000;
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
 
@@ -105,43 +104,80 @@ int main(int argc, char **argv)
         image.savePNG("mandelbrot_cpu.png");
     }
 
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляние на лог,
+        // передав printLog=true - скорее всего в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float,
+        // то это означает что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = true;
+        kernel.compile(printLog);
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+        gpu::WorkSize ws(16,16, width, height);
 
-    // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
+        gpu::shared_device_buffer_typed<float> resultsBuffer;
+
+        auto pointsCount = gpu_results.width * gpu_results.height;
+
+        resultsBuffer.growN(pointsCount);
+        {
+
+            timer t;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                kernel.exec(ws,
+                            resultsBuffer,
+                            width,
+                            height,
+                            centralX - sizeX / 2.0f,
+                            centralY - sizeY / 2.0f,
+                            sizeX,
+                            sizeY,
+                            iterationsLimit);
+                t.nextLap();
+            }
+            resultsBuffer.readN(gpu_results.ptr(), pointsCount);
+            size_t flopsInLoop = 10;
+            size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+            size_t gflops = pow(10, 9);// 1000*1000*1000;
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+            double realIterationsFraction = 0.0;
+            for (int j = 0; j < height; ++j) {
+                for (int i = 0; i < width; ++i) {
+                    realIterationsFraction += gpu_results.ptr()[j * width + i];
+                }
+            }
+            std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                      << std::endl;
+
+            renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+            image.savePNG("mandelbrot_gpu.png");
+        }
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
+
+    // Это бонус ввиде интерактивной отрисовки, не забудьте запустить на ГПУ чтобы посмотреть в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
 //    bool useGPU = false;

--- a/src/main_max_prefix_sum.cpp
+++ b/src/main_max_prefix_sum.cpp
@@ -1,7 +1,10 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
 
+#include "cl/max_prefix_sum_cl.h"
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
@@ -20,7 +23,7 @@ int main(int argc, char **argv)
     int benchmarkingIters = 10;
     int max_n = (1 << 24);
 
-    for (int n = 2; n <= max_n; n *= 2) {
+    for (int n = 1 << 10; n <= max_n; n *= 2) {
         std::cout << "______________________________________________" << std::endl;
         int values_range = std::min(1023, std::numeric_limits<int>::max() / n);
         std::cout << "n=" << n << " values in range: [" << (-values_range) << "; " << values_range << "]" << std::endl;
@@ -70,8 +73,123 @@ int main(int argc, char **argv)
             std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
         }
 
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
         {
-            // TODO: implement on OpenCL
+            ocl::Kernel kernel(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "sum");
+
+            bool printLog = false;
+            kernel.compile(printLog);
+
+            //device.printInfo();
+
+            gpu::WorkSize ws(32, n);
+
+            gpu::shared_device_buffer_typed<int> numbersBuffer;
+            numbersBuffer.growN(*ws.clGlobalSize());
+
+            as.resize(*ws.clGlobalSize());
+            numbersBuffer.writeN(as.data(), as.size());
+
+            gpu::shared_device_buffer_typed<int> resultsBuffer;
+            gpu::shared_device_buffer_typed<int> maxPrefixPerGroupBuffer;
+            gpu::shared_device_buffer_typed<int> maxPrefixIndexPerGroupBuffer;
+
+            auto pointsCount = ceil(*ws.clGlobalSize() / *ws.clLocalSize());
+
+            resultsBuffer.growN(pointsCount);
+            maxPrefixPerGroupBuffer.growN(pointsCount);
+            maxPrefixIndexPerGroupBuffer.growN(pointsCount);
+
+            {
+                timer t;
+                for (int i = 0; i < benchmarkingIters; ++i) {
+
+                    std::vector<int> accumulatedValues(pointsCount, 0);
+                    std::vector<int> maxPrefixPerGroup(pointsCount, 0);
+                    std::vector<int> maxPrefixIndexPerGroup(pointsCount, 0);
+
+                    resultsBuffer.writeN(accumulatedValues.data(), accumulatedValues.size());
+
+                    kernel.exec(ws,
+                                numbersBuffer,
+                                resultsBuffer,
+                                maxPrefixPerGroupBuffer,
+                                maxPrefixIndexPerGroupBuffer);
+
+                    resultsBuffer.readN(accumulatedValues.data(), pointsCount);
+                    maxPrefixPerGroupBuffer.readN(maxPrefixPerGroup.data(), pointsCount);
+                    maxPrefixIndexPerGroupBuffer.readN(maxPrefixIndexPerGroup.data(), pointsCount);
+
+                    int sum = 0;
+                    int maxSum = 0;
+                    int maxPrefixIndex = 0;
+                    int blockIndex = 0;
+                    for(int i = 0; i < accumulatedValues.size(); i++) {
+                        int value = accumulatedValues[i];
+                        sum += value;
+
+                        int prefix = maxPrefixPerGroup[i];
+                        if( (sum - value) + prefix > maxSum ) {
+                            blockIndex = i;
+                            maxSum = (sum - value) + prefix;
+                            maxPrefixIndex = maxPrefixIndexPerGroup[blockIndex];
+                        } else if ( sum > maxSum ) {
+                            maxSum = sum;
+                            blockIndex = i;
+                        }
+                    }
+
+                    int currentBlockMaxSum = maxSum;
+                    int currentBlockMaxSumIndex = maxPrefixIndexPerGroup[blockIndex];
+                    if (blockIndex < maxPrefixPerGroup.size()) {
+
+                        int blockMaxPrefix = maxPrefixPerGroup[blockIndex];
+                        int blockSum = accumulatedValues[blockIndex];
+
+                        if(blockMaxPrefix > blockSum) {
+                            currentBlockMaxSum -= blockSum;
+                            currentBlockMaxSum += blockMaxPrefix;
+                            currentBlockMaxSumIndex = maxPrefixIndexPerGroup[blockIndex];
+                        }
+                    }
+
+                    int nextBlockMaxSum = maxSum;
+                    int nextBlockMaxSumIndex = maxPrefixIndexPerGroup[blockIndex];
+                    if (blockIndex < maxPrefixPerGroup.size() - 1) {
+
+                        int blockMaxPrefix = maxPrefixPerGroup[blockIndex + 1];
+                        int blockSum = accumulatedValues[blockIndex + 1];
+
+                        if(blockMaxPrefix > blockSum) {
+                            nextBlockMaxSum += blockMaxPrefix;
+                            nextBlockMaxSumIndex = maxPrefixIndexPerGroup[blockIndex + 1];
+                        }
+                    }
+
+                    if (maxPrefixIndex == 0) {
+                        if (currentBlockMaxSum > nextBlockMaxSum) {
+                            maxSum = currentBlockMaxSum;
+                            maxPrefixIndex = currentBlockMaxSumIndex;
+                        } else {
+                            maxSum = nextBlockMaxSum;
+                            maxPrefixIndex = nextBlockMaxSumIndex;
+                        }
+                    }
+
+                    maxPrefixIndex++;
+
+                    EXPECT_THE_SAME(reference_result, maxPrefixIndex, "CPU GPU result should be consistent!");
+                    EXPECT_THE_SAME(reference_max_sum, maxSum, "CPU GPU result should be consistent!");
+
+                    t.nextLap();
+                }
+
+                std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+                std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+            }
         }
     }
 }


### PR DESCRIPTION
**Мандельброт**
=========
```
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
CPU: 0.302565+-0.00271596 s
CPU: 33.0507 GFlops
    Real iterations fraction: 40.7076%
Building kernels for Intel(R) UHD Graphics 630... 
Kernels compilation done in 0.11896 seconds
Device 1
	Program build log:


GPU: 0.0511182+-0.00738353 s
GPU: 195.625 GFlops
    Real iterations fraction: 40.7078%
GPU vs CPU average results difference: 0.019951%
```

**Сумма**
=========
```
CPU:     0.206539+-0.000755742 s
CPU:     484.17 millions/s
CPU OMP: 0.0343935+-0.000933022 s
CPU OMP: 2907.53 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Building kernels for Intel(R) UHD Graphics 630... 
Kernels compilation done in 0.089206 seconds
Device 1
	Program build log:


Using device: Intel(R) UHD Graphics 630, 24 compute units, 1536 MB global memory, OpenCL 1.2
  driver version: 1.2(Aug 31 2020 22:24:18), platform version: OpenCL 1.2 (Jun  8 2020 17:36:15)
  max work group size 256
  max work item sizes [256, 256, 256]
  max mem alloc size 384 MB
GPU: 0.153686+-0.0136641 s
GPU: 650.677 millions/s
```

**Максимальный по сумме префикс**
=========
```
n=1024 values in range: [-1023; 1023]
Max prefix sum: 14708 on prefix [0; 829)
CPU: 3.66667e-06+-4.71405e-07 s
CPU: 279.273 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.00109117+-1.12014e-05 s
GPU: 0.938445 millions/s
______________________________________________
n=2048 values in range: [-1023; 1023]
Max prefix sum: 22303 on prefix [0; 1779)
CPU: 6.5e-06+-5e-07 s
CPU: 315.077 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.00116567+-4.70343e-05 s
GPU: 1.75693 millions/s
______________________________________________
n=4096 values in range: [-1023; 1023]
Max prefix sum: 4292 on prefix [0; 58)
CPU: 1.2e-05+-0 s
CPU: 341.333 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.00117583+-3.00023e-05 s
GPU: 3.48349 millions/s
______________________________________________
n=8192 values in range: [-1023; 1023]
Max prefix sum: 3297 on prefix [0; 470)
CPU: 2.3e-05+-1e-06 s
CPU: 356.174 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.00117083+-0.000100169 s
GPU: 6.99673 millions/s
______________________________________________
n=16384 values in range: [-1023; 1023]
Max prefix sum: 103982 on prefix [0; 10101)
CPU: 4.9e-05+-5.7735e-07 s
CPU: 334.367 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.00120583+-8.20029e-05 s
GPU: 13.5873 millions/s
______________________________________________
n=32768 values in range: [-1023; 1023]
Max prefix sum: 75785 on prefix [0; 2074)
CPU: 9.38333e-05+-2.11476e-06 s
CPU: 349.215 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.001152+-2.63502e-05 s
GPU: 28.4444 millions/s
______________________________________________
n=65536 values in range: [-1023; 1023]
Max prefix sum: 93500 on prefix [0; 61715)
CPU: 0.000185833+-3.72678e-07 s
CPU: 352.66 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.00144017+-6.25284e-05 s
GPU: 45.5058 millions/s
______________________________________________
n=131072 values in range: [-1023; 1023]
Max prefix sum: 310443 on prefix [0; 102163)
CPU: 0.000604+-3.34465e-05 s
CPU: 217.007 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.002001+-4.42305e-05 s
GPU: 65.5032 millions/s
______________________________________________
n=262144 values in range: [-1023; 1023]
Max prefix sum: 449686 on prefix [0; 211310)
CPU: 0.000816333+-7.14998e-05 s
CPU: 321.124 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.00347917+-0.000789682 s
GPU: 75.3468 millions/s
______________________________________________
n=524288 values in range: [-1023; 1023]
Max prefix sum: 18511 on prefix [0; 470827)
CPU: 0.0014295+-1.61838e-05 s
CPU: 366.763 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.004482+-0.000287351 s
GPU: 116.976 millions/s
______________________________________________
n=1048576 values in range: [-1023; 1023]
Max prefix sum: 46638 on prefix [0; 12341)
CPU: 0.0029295+-2.01969e-05 s
CPU: 357.937 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.0100815+-0.000773353 s
GPU: 104.01 millions/s
______________________________________________
n=2097152 values in range: [-1023; 1023]
Max prefix sum: 1199401 on prefix [0; 1691780)
CPU: 0.00490117+-8.86631e-05 s
CPU: 427.888 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.0191828+-0.00146598 s
GPU: 109.324 millions/s
______________________________________________
n=4194304 values in range: [-511; 511]
Max prefix sum: 43576 on prefix [0; 3543860)
CPU: 0.0102882+-0.000152654 s
CPU: 407.682 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.0372657+-0.00974132 s
GPU: 112.551 millions/s
______________________________________________
n=8388608 values in range: [-255; 255]
Max prefix sum: 262168 on prefix [0; 2631415)
CPU: 0.0221472+-0.00124643 s
CPU: 378.767 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.0497245+-0.00977522 s
GPU: 168.702 millions/s
______________________________________________
n=16777216 values in range: [-127; 127]
Max prefix sum: 79474 on prefix [0; 976207)
CPU: 0.0409883+-0.000487339 s
CPU: 409.317 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 8176 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
GPU: 0.0686278+-0.0106514 s
GPU: 244.467 millions/s

```