### PR TITLE
Task03 Rustam Sadykov SPbSU

### DIFF
--- a/src/cl/aplusb.cl
+++ b/src/cl/aplusb.cl
@@ -1,23 +1,24 @@
 #ifdef __CLION_IDE__
+
 #include <libgpu/opencl/cl/clion_defines.cl>
+
 #endif
 
 #line 6
 
-__kernel void aplusb(__global const float* a,
-                     __global const float* b,
-                     __global       float* c,
-                     unsigned int n)
-{
-    const unsigned int index = get_global_id(0);
+__kernel void aplusb(__global const float *a,
+                     __global const float *b,
+                     __global       float *c,
+                     unsigned int n) {
+  const unsigned int index = get_global_id(0);
 
-    if (index >= n)
-        return;
+  if (index >= n)
+    return;
 
-    if (index == 0) {
-        // Если бы printf был не под if, то printf попытался бы исполниться для всех запущенных workItems
-        printf("Just example of printf usage: WARP_SIZE=%d\n", WARP_SIZE);
-    }
+  if (index == 0) {
+    // Если бы printf был не под if, то printf попытался бы исполниться для всех запущенных workItems
+    printf("Just example of printf usage: WARP_SIZE=%d\n", WARP_SIZE);
+  }
 
-    c[index] = a[index] + b[index];
+  c[index] = a[index] + b[index];
 }

--- a/src/cl/clion_defines.cl
+++ b/src/cl/clion_defines.cl
@@ -68,6 +68,6 @@ size_t	get_global_offset	(uint dimindx);
 #endif
 
 // 64 for AMD, 32 for NVidia, 8 for intel GPUs, 1 for CPU
-#define WARP_SIZE 64
+#define WARP_SIZE 32
 
 #endif // pragma once

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -1,13 +1,46 @@
 #ifdef __CLION_IDE__
+
 #include <libgpu/opencl/cl/clion_defines.cl>
+
 #endif
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
-    // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
-    // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
-    // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
-    // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+__kernel void mandelbrot(
+        __global float *results,
+        unsigned int width, unsigned int height,
+        float fromX, float fromY,
+        float sizeX, float sizeY,
+        unsigned int iters, int smoothing) {
+  const float threshold = 256.0f;
+  const float threshold2 = threshold * threshold;
+
+  const int i = get_global_id(0);
+  const int j = get_global_id(1);
+
+  if (i >= width || j >= height)
+    return;
+
+  const float x0 = fromX + (i + 0.5f) * sizeX / width;
+  const float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+  float x = x0;
+  float y = y0;
+  int iter = 0;
+  for (; iter < iters; ++iter) {
+    float xPrev = x;
+    x = x * x - y * y + x0;
+    y = 2.0f * xPrev * y + y0;
+    if ((x * x + y * y) > threshold2) {
+      break;
+    }
+  }
+
+  float result = iter;
+  if (smoothing && iter != iters) {
+    result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+  }
+
+  result = 1.0f * result / iters;
+  results[j * width + i] = result;
 }

--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -1,1 +1,55 @@
-// TODO
+#ifdef __CLION_IDE__
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
+#endif
+
+#ifndef WORK_GROUP_SIZE
+#define WORK_GROUP_SIZE 128
+#endif
+
+#line 6
+
+__kernel void max_prefix(
+        __global int *buffer,
+        int len) {
+  const int localId = get_local_id(0);
+  const int globalId = get_global_id(0);
+  const int groupId = get_group_id(0);
+
+  __local int uploaded[3 * WORK_GROUP_SIZE];
+
+  for (int i = 0; i < 3; i++) {
+    uploaded[i * WORK_GROUP_SIZE + localId] = buffer[3 * groupId * WORK_GROUP_SIZE + i * WORK_GROUP_SIZE + localId];
+  }
+
+  //TODO : optimize
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  if (globalId < len) {
+    if (localId == 0) {
+      int sum = 0;
+      int res = 0;
+      int max_sum = 0;
+      for (int i = 0; i < min(WORK_GROUP_SIZE, len - globalId); ++i) {
+        int part_sum = uploaded[3 * i + 0];
+        int part_res = uploaded[3 * i + 1];
+        int part_max_sum = uploaded[3 * i + 2] + sum;
+        if (max_sum < part_max_sum)
+          max_sum = part_max_sum, res = part_res;
+        sum += part_sum;
+      }
+      uploaded[0] = sum;
+      uploaded[1] = res;
+      uploaded[2] = max_sum;
+//      printf("---------LOG : global_id=%d, len=%d, ans=(%d, %d, %d)\n", globalId, *len, max_sum, res, sum);
+    }
+  }
+
+  if (localId == 0 && globalId < len) {
+    // replace results back
+    buffer[3 * groupId * WORK_GROUP_SIZE + 0] = uploaded[0];
+    buffer[3 * groupId * WORK_GROUP_SIZE + 1] = uploaded[1];
+    buffer[3 * groupId * WORK_GROUP_SIZE + 2] = uploaded[2];
+  }
+}

--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -10,6 +10,43 @@
 
 #line 6
 
+__kernel void init_buffer(
+        __global int *buffer,
+        __global const int *a,
+        int n) {
+  const int i = get_global_id(0);
+  if (i < n) {
+    buffer[3 * i + 0] = a[i];
+    if (a[i] > 0) {
+      buffer[3 * i + 1] = i + 1;
+      buffer[3 * i + 2] = a[i];
+    } else {
+      buffer[3 * i + 1] = i;
+      buffer[3 * i + 2] = 0;
+    }
+  } else {
+    buffer[3 * i + 0] = 0;
+    buffer[3 * i + 1] = i;
+    buffer[3 * i + 2] = 0;
+  }
+}
+
+
+__kernel void reorder_buffer(
+        __global int *buffer,
+        int len) {
+  const int globalId = get_global_id(0);
+
+  if (globalId == 0) {
+    int cnt = (len + WORK_GROUP_SIZE - 1) / WORK_GROUP_SIZE;
+    for (int i = 1; i < cnt; ++i) {
+      buffer[3 * i + 0] = buffer[3 * (i * WORK_GROUP_SIZE) + 0];
+      buffer[3 * i + 1] = buffer[3 * (i * WORK_GROUP_SIZE) + 1];
+      buffer[3 * i + 2] = buffer[3 * (i * WORK_GROUP_SIZE) + 2];
+    }
+  }
+}
+
 __kernel void max_prefix(
         __global int *buffer,
         int len) {
@@ -42,7 +79,7 @@ __kernel void max_prefix(
       uploaded[0] = sum;
       uploaded[1] = res;
       uploaded[2] = max_sum;
-//      printf("---------LOG : global_id=%d, len=%d, ans=(%d, %d, %d)\n", globalId, *len, max_sum, res, sum);
+//      printf("---------LOG : global_id=%d, len=%d, ans=(%d, %d, %d)\n", globalId, len, max_sum, res, sum);
     }
   }
 

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,34 @@
-// TODO
+#ifdef __CLION_IDE__
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
+#endif
+
+#ifndef WORK_GROUP_SIZE
+#define WORK_GROUP_SIZE 128
+#endif
+
+#line 6
+
+__kernel void bad_sum(
+        __global const unsigned int *source,
+        __global unsigned int *result,
+        unsigned int n) {
+  const int localId = get_local_id(0);
+  const int globalId = get_global_id(0);
+
+  __local unsigned int uploaded[WORK_GROUP_SIZE];
+  if (globalId >= n)
+    uploaded[localId] = 0;
+  else
+    uploaded[localId] = source[globalId];
+
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  if (localId == 0) {
+    unsigned int res = 0;
+    for (int i = 0; i < WORK_GROUP_SIZE; i++)
+      res += uploaded[i];
+    atomic_add(result, res);
+  }
+}

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -32,3 +32,34 @@ __kernel void bad_sum(
     atomic_add(result, res);
   }
 }
+
+__kernel void opt_sum(
+        __global const unsigned int *source,
+        __global unsigned int *result,
+        unsigned int n) {
+  const int localId = get_local_id(0);
+  const int globalId = get_global_id(0);
+
+  __local unsigned int uploaded[WORK_GROUP_SIZE];
+  if (globalId >= n)
+    uploaded[localId] = 0;
+  else
+    uploaded[localId] = source[globalId];
+
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  for (unsigned int len = WORK_GROUP_SIZE / 2; len > 0; len /= 2) {
+    if (localId < len) {
+      unsigned int a = uploaded[localId];
+      unsigned int b = uploaded[localId + len];
+      uploaded[localId] = a + b;
+    }
+    if (len > WARP_SIZE)
+      barrier(CLK_LOCAL_MEM_FENCE);
+    else if (2 * localId >= len)
+      return;
+  }
+
+  if (localId == 0)
+    atomic_add(result, uploaded[0]);
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -9,260 +9,298 @@
 #include "cl/mandelbrot_cl.h"
 
 
-void mandelbrotCPU(float* results,
+void mandelbrotCPU(float *results,
                    unsigned int width, unsigned int height,
                    float fromX, float fromY,
                    float sizeX, float sizeY,
-                   unsigned int iters, bool smoothing)
-{
-    const float threshold = 256.0f;
-    const float threshold2 = threshold * threshold;
-    
-    #pragma omp parallel for
-    for (int j = 0; j < height; ++j) {
-        for (int i = 0; i < width; ++i) {
-            float x0 = fromX + (i + 0.5f) * sizeX / width;
-            float y0 = fromY + (j + 0.5f) * sizeY / height;
+                   unsigned int iters, bool smoothing) {
+  const float threshold = 256.0f;
+  const float threshold2 = threshold * threshold;
 
-            float x = x0;
-            float y = y0;
+#pragma omp parallel for
+  for (int j = 0; j < height; ++j) {
+    for (int i = 0; i < width; ++i) {
+      float x0 = fromX + (i + 0.5f) * sizeX / width;
+      float y0 = fromY + (j + 0.5f) * sizeY / height;
 
-            int iter = 0;
-            for (; iter < iters; ++iter) {
-                float xPrev = x;
-                x = x * x - y * y + x0;
-                y = 2.0f * xPrev * y + y0;
-                if ((x * x + y * y) > threshold2) {
-                    break;
-                }
-            }
-            float result = iter;
-            if (smoothing && iter != iters) {
-                result = result - logf(logf(sqrtf(x * x + y * y)) / logf(threshold)) / logf(2.0f);
-            }
+      float x = x0;
+      float y = y0;
 
-            result = 1.0f * result / iters;
-            results[j * width + i] = result;
+      int iter = 0;
+      for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+          break;
         }
+      }
+      float result = iter;
+      if (smoothing && iter != iters) {
+        result = result - logf(logf(sqrtf(x * x + y * y)) / logf(threshold)) / logf(2.0f);
+      }
+
+      result = 1.0f * result / iters;
+      results[j * width + i] = result;
     }
+  }
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb, unsigned int width, unsigned int height);
+void renderToColor(const float *results, unsigned char *img_rgb, unsigned int width, unsigned int height);
 
 void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU);
 
 
-int main(int argc, char **argv)
-{
-    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+int main(int argc, char **argv) {
+  gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-    unsigned int benchmarkingIters = 10;
+  unsigned int benchmarkingIters = 10;
 
-    unsigned int width = 2048;
-    unsigned int height = 2048;
-    unsigned int iterationsLimit = 256;
+  unsigned int width = 2048;
+  unsigned int height = 2048;
+  unsigned int iterationsLimit = 256;
 
-    float centralX = -0.789136f;
-    float centralY = -0.150316f;
-    float sizeX = 0.00239f;
+  float centralX = -0.789136f;
+  float centralY = -0.150316f;
+  float sizeX = 0.00239f;
 
-//    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
-//    float centralX = -0.5f;
-//    float centralY = 0.0f;
-//    float sizeX = 2.0f;
+//  // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
+//  float centralX = -0.5f;
+//  float centralY = 0.0f;
+//  float sizeX = 2.0f;
 
-    images::Image<float> cpu_results(width, height, 1);
-    images::Image<float> gpu_results(width, height, 1);
-    images::Image<unsigned char> image(width, height, 3);
+  images::Image<float> cpu_results(width, height, 1);
+  images::Image<float> gpu_results(width, height, 1);
+  images::Image<unsigned char> image(width, height, 3);
 
-    float sizeY = sizeX * height / width;
+  float sizeY = sizeX * height / width;
 
-    {
-        timer t;
-        for (int i = 0; i < benchmarkingIters; ++i) {
-            mandelbrotCPU(cpu_results.ptr(),
-                          width, height,
-                          centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                          sizeX, sizeY,
-                          iterationsLimit, false);
-            t.nextLap();
-        }
-        size_t flopsInLoop = 10;
-        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
-        std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
-
-        double realIterationsFraction = 0.0;
-        for (int j = 0; j < height; ++j) {
-            for (int i = 0; i < width; ++i) {
-                realIterationsFraction += cpu_results.ptr()[j * width + i];
-            }
-        }
-        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
-
-        renderToColor(cpu_results.ptr(), image.ptr(), width, height);
-        image.savePNG("mandelbrot_cpu.png");
+  {
+    timer t;
+    for (int i = 0; i < benchmarkingIters; ++i) {
+      mandelbrotCPU(cpu_results.ptr(),
+                    width, height,
+                    centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                    sizeX, sizeY,
+                    iterationsLimit, false);
+      t.nextLap();
     }
+    size_t flopsInLoop = 10;
+    size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+    size_t gflops = 1000 * 1000 * 1000;
+    std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+    double realIterationsFraction = 0.0;
+    for (int j = 0; j < height; ++j) {
+      for (int i = 0; i < width; ++i) {
+        realIterationsFraction += cpu_results.ptr()[j * width + i];
+      }
+    }
+    std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+              << std::endl;
+
+    renderToColor(cpu_results.ptr(), image.ptr(), width, height);
+    std::string file = "mandelbrot_cpu.png";
+    remove(file.c_str());
+    image.savePNG(file.c_str());
+  }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+  // Раскомментируйте это:
 
-    // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
-    // Кликами мышки можно смещать ракурс
-    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+  gpu::Context context;
+  context.init(device.device_id_opencl);
+  context.activate();
+  {
+    ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+    // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+    // передав printLog=true - скорее всего, в логе будет строчка вроде
+    // Kernel <mandelbrot> was successfully vectorized (8)
+    // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+    // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+    // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+    // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+    bool printLog = false;
+    kernel.compile(printLog);
+    int groupSizeX = 32; //warp size
+    int groupSizeY = 128 / groupSizeX;
+    int workSizeX = ((int) width + groupSizeX - 1) / groupSizeX * groupSizeX;
+    int workSizeY = ((int) height + groupSizeY - 1) / groupSizeY * groupSizeY;
+    gpu::WorkSize workSize(groupSizeX, groupSizeY, workSizeX, workSizeY);
 
-    return 0;
+    gpu::gpu_mem_32f res_gpu;
+    res_gpu.resizeN(width * height);
+
+    timer t;
+    for (int i = 0; i < benchmarkingIters; ++i) {
+      kernel.exec(workSize, res_gpu,
+                  width, height,
+                  centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                  sizeX, sizeY,
+                  iterationsLimit, 0);
+      t.nextLap();
+    }
+    std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    size_t flopsInLoop = 10;
+    size_t workItems = workSizeX * workSizeY;
+    size_t maxApproximateFlops = workItems * iterationsLimit * flopsInLoop;
+    size_t gflops = 1000 * 1000 * 1000;
+    std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+    res_gpu.readN(gpu_results.ptr(), width * height);
+
+    double realIterationsFraction = 0.0;
+    for (int j = 0; j < height; ++j) {
+      for (int i = 0; i < width; ++i) {
+        realIterationsFraction += gpu_results.ptr()[j * width + i];
+      }
+    }
+    std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (workItems) << "%"
+              << std::endl;
+
+    renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+    std::string file = "mandelbrot_gpu.png";
+    remove(file.c_str());
+    image.savePNG(file.c_str());
+  }
+
+  {
+    double errorAvg = 0.0;
+    for (int j = 0; j < height; ++j) {
+      for (int i = 0; i < width; ++i) {
+        errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+      }
+    }
+    errorAvg /= width * height;
+    std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+    if (errorAvg > 0.03) {
+      throw std::runtime_error("Too high difference between CPU and GPU results!");
+    }
+  }
+
+//  // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
+//  // Кликами мышки можно смещать ракурс
+//  // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы
+//  bool useGPU = true;
+//  renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+
+  return 0;
 }
 
-void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU)
-{
-    images::ImageWindow window("Mandelbrot");
+void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU) {
+  images::ImageWindow window("Mandelbrot");
 
-    unsigned int width = 1024;
-    unsigned int height = 1024;
+  unsigned int width = 1024;
+  unsigned int height = 1024;
 
-    float sizeX = 2.0f;
-    float sizeY = sizeX * height / width;
+  float sizeX = 2.0f;
+  float sizeY = sizeX * height / width;
 
-    float zoomingSpeed = 1.005f;
+  float zoomingSpeed = 1.105f;
 
-    images::Image<float> results(width, height, 1);
-    images::Image<unsigned char> image(width, height, 3);
+  images::Image<float> results(width, height, 1);
+  images::Image<unsigned char> image(width, height, 3);
 
-    ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-    gpu::gpu_mem_32f results_vram;
-    if (useGPU) {
-        kernel.compile();
-        results_vram.resizeN(width * height);
+  ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+  gpu::gpu_mem_32f results_vram;
+  if (useGPU) {
+    kernel.compile();
+    results_vram.resizeN(width * height);
+  }
+
+  do {
+    if (!useGPU) {
+      mandelbrotCPU(results.ptr(), width, height,
+                    centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                    sizeX, sizeY,
+                    iterationsLimit, true);
+    } else {
+      kernel.exec(gpu::WorkSize(16, 16, width, height),
+                  results_vram, width, height,
+                  centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                  sizeX, sizeY,
+                  iterationsLimit, 1);
+      results_vram.readN(results.ptr(), width * height);
     }
+    renderToColor(results.ptr(), image.ptr(), width, height);
 
-    do {
-        if (!useGPU) {
-            mandelbrotCPU(results.ptr(), width, height,
-                          centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                          sizeX, sizeY,
-                          iterationsLimit, true);
-        } else {
-            kernel.exec(gpu::WorkSize(16, 16, width, height),
-                        results_vram, width, height,
-                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                        sizeX, sizeY,
-                        iterationsLimit, 1);
-            results_vram.readN(results.ptr(), width * height);
-        }
-        renderToColor(results.ptr(), image.ptr(), width, height);
+    window.display(image);
+    window.wait(30);
 
-        window.display(image);
-        window.wait(30);
+    if (window.getMouseClick() == MOUSE_LEFT) {
+      centralX = centralX - sizeX * 0.5f + sizeX * window.getMouseX() / width;
+      centralY = centralY - sizeY * 0.5f + sizeY * window.getMouseY() / height;
+      std::cout << "Focus: " << centralX << " " << centralY << " " << sizeX << std::endl;
+    }
+    if (window.isResized()) {
+      window.resize();
+      width = window.width();
+      height = window.height();
+      std::cout << "Resized to " << width << "x" << height << std::endl;
 
-        if (window.getMouseClick() == MOUSE_LEFT) {
-            centralX = centralX - sizeX * 0.5f + sizeX * window.getMouseX() / width;
-            centralY = centralY - sizeY * 0.5f + sizeY * window.getMouseY() / height;
-            std::cout << "Focus: " << centralX << " " << centralY  << " " << sizeX << std::endl;
-        }
-        if (window.isResized()) {
-            window.resize();
-            width = window.width();
-            height = window.height();
-            std::cout << "Resized to " << width << "x" << height << std::endl;
+      sizeY = sizeX * height / width;
 
-            sizeY = sizeX * height / width;
+      results = images::Image<float>(width, height, 1);
+      image = images::Image<unsigned char>(width, height, 3);
 
-            results = images::Image<float>(width, height, 1);
-            image = images::Image<unsigned char>(width, height, 3);
-
-            if (useGPU) {
-                results_vram.resizeN(width * height);
-            }
-        }
-        sizeX /= zoomingSpeed;
-        sizeY /= zoomingSpeed;
-    } while (!window.isClosed());
+      if (useGPU) {
+        results_vram.resizeN(width * height);
+      }
+    }
+    sizeX /= zoomingSpeed;
+    sizeY /= zoomingSpeed;
+  } while (!window.isClosed());
 }
 
 
 struct vec3f {
-    vec3f(float x, float y, float z) : x(x), y(y), z(z) {}
+  vec3f(float x, float y, float z) : x(x), y(y), z(z) {}
 
-    float x; float y; float z;
+  float x;
+  float y;
+  float z;
 };
 
 vec3f operator+(const vec3f &a, const vec3f &b) {
-    return {a.x + b.x, a.y + b.y, a.z + b.z};
+  return {a.x + b.x, a.y + b.y, a.z + b.z};
 }
 
 vec3f operator*(const vec3f &a, const vec3f &b) {
-    return {a.x * b.x, a.y * b.y, a.z * b.z};
+  return {a.x * b.x, a.y * b.y, a.z * b.z};
 }
 
 vec3f operator*(const vec3f &a, float t) {
-    return {a.x * t, a.y * t, a.z * t};
+  return {a.x * t, a.y * t, a.z * t};
 }
 
 vec3f operator*(float t, const vec3f &a) {
-    return a * t;
+  return a * t;
 }
 
 vec3f sin(const vec3f &a) {
-    return {sinf(a.x), sinf(a.y), sinf(a.z)};
+  return {sinf(a.x), sinf(a.y), sinf(a.z)};
 }
 
 vec3f cos(const vec3f &a) {
-    return {cosf(a.x), cosf(a.y), cosf(a.z)};
+  return {cosf(a.x), cosf(a.y), cosf(a.z)};
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb,
-             unsigned int width, unsigned int height)
-{
-    #pragma omp parallel for
-    for (int j = 0; j < height; ++j) {
-        for (int i = 0; i < width; ++i) {
-            // Палитра взята отсюда: http://iquilezles.org/www/articles/palettes/palettes.htm
-            float t = results[j * width + i];
-            vec3f a(0.5, 0.5, 0.5);
-            vec3f b(0.5, 0.5, 0.5);
-            vec3f c(1.0, 0.7, 0.4);
-            vec3f d(0.00, 0.15, 0.20);
-            vec3f color = a + b * cos(2*3.14f*(c*t+d));
-            img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char) (color.x * 255);
-            img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char) (color.y * 255);
-            img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char) (color.z * 255);
-        }
+void renderToColor(const float *results, unsigned char *img_rgb,
+                   unsigned int width, unsigned int height) {
+#pragma omp parallel for
+  for (int j = 0; j < height; ++j) {
+    for (int i = 0; i < width; ++i) {
+      // Палитра взята отсюда: http://iquilezles.org/www/articles/palettes/palettes.htm
+      float t = results[j * width + i];
+      vec3f a(0.5, 0.5, 0.5);
+      vec3f b(0.5, 0.5, 0.5);
+      vec3f c(1.0, 0.7, 0.4);
+      vec3f d(0.00, 0.15, 0.20);
+      vec3f color = a + b * cos(2 * 3.14f * (c * t + d));
+      img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char) (color.x * 255);
+      img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char) (color.y * 255);
+      img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char) (color.z * 255);
     }
+  }
 }

--- a/src/main_max_prefix_sum.cpp
+++ b/src/main_max_prefix_sum.cpp
@@ -1,77 +1,150 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
 
+#include "cl/max_prefix_sum_cl.h"
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
-    if (a != b) {
-        std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
-        throw std::runtime_error(message);
-    }
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+  if (a != b) {
+    std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
+    throw std::runtime_error(message);
+  }
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
-
-int main(int argc, char **argv)
-{
-    int benchmarkingIters = 10;
-    int max_n = (1 << 24);
-
-    for (int n = 2; n <= max_n; n *= 2) {
-        std::cout << "______________________________________________" << std::endl;
-        int values_range = std::min(1023, std::numeric_limits<int>::max() / n);
-        std::cout << "n=" << n << " values in range: [" << (-values_range) << "; " << values_range << "]" << std::endl;
-
-        std::vector<int> as(n, 0);
-        FastRandom r(n);
-        for (int i = 0; i < n; ++i) {
-            as[i] = (unsigned int) r.next(-values_range, values_range);
-        }
-
-        int reference_max_sum;
-        int reference_result;
-        {
-            int max_sum = 0;
-            int sum = 0;
-            int result = 0;
-            for (int i = 0; i < n; ++i) {
-                sum += as[i];
-                if (sum > max_sum) {
-                    max_sum = sum;
-                    result = i + 1;
-                }
-            }
-            reference_max_sum = max_sum;
-            reference_result = result;
-        }
-        std::cout << "Max prefix sum: " << reference_max_sum << " on prefix [0; " << reference_result << ")" << std::endl;
-
-        {
-            timer t;
-            for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                int max_sum = 0;
-                int sum = 0;
-                int result = 0;
-                for (int i = 0; i < n; ++i) {
-                    sum += as[i];
-                    if (sum > max_sum) {
-                        max_sum = sum;
-                        result = i + 1;
-                    }
-                }
-                EXPECT_THE_SAME(reference_max_sum, max_sum, "CPU result should be consistent!");
-                EXPECT_THE_SAME(reference_result, result, "CPU result should be consistent!");
-                t.nextLap();
-            }
-            std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-            std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
-        }
-
-        {
-            // TODO: implement on OpenCL
-        }
+void init_buffer(
+        int *buffer,
+        const int *a,
+        int n, int workSize) {
+  for (int i = 0; i < workSize; i++) {
+    if (i < n) {
+      buffer[3 * i + 0] = a[i];
+      if (a[i] > 0) {
+        buffer[3 * i + 1] = i + 1;
+        buffer[3 * i + 2] = a[i];
+      } else {
+        buffer[3 * i + 1] = i;
+        buffer[3 * i + 2] = 0;
+      }
+    } else {
+      buffer[3 * i + 0] = 0;
+      buffer[3 * i + 1] = i;
+      buffer[3 * i + 2] = 0;
     }
+  }
+}
+
+void reorder_buffer(int *buffer, int len, int groupSize) {
+  int cnt = (len + groupSize - 1) / groupSize;
+  for (int i = 1; i < cnt; ++i) {
+    buffer[3 * i + 0] = buffer[3 * (i * groupSize) + 0];
+    buffer[3 * i + 1] = buffer[3 * (i * groupSize) + 1];
+    buffer[3 * i + 2] = buffer[3 * (i * groupSize) + 2];
+  }
+}
+
+int main(int argc, char **argv) {
+  gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+  gpu::Context context;
+  context.init(device.device_id_opencl);
+  context.activate();
+
+  size_t groupSize = 128;
+
+  std::string defines = " -D WORK_GROUP_SIZE=" + to_string(groupSize);
+  ocl::Kernel kernel(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "max_prefix", defines);
+  kernel.compile();
+
+  gpu::gpu_mem_32i buffer_gpu;
+
+  int benchmarkingIters = 1;
+  int max_n = (1 << 24);
+
+  for (int n = 2; n <= max_n; n *= 2) {
+    std::cout << "______________________________________________" << std::endl;
+    int values_range = std::min(1023, std::numeric_limits<int>::max() / n);
+    std::cout << "n=" << n << " values in range: [" << (-values_range) << "; " << values_range << "]" << std::endl;
+
+    std::vector<int> as(n, 0);
+    FastRandom r(n);
+    for (int i = 0; i < n; ++i) {
+      as[i] = (unsigned int) r.next(-values_range, values_range);
+    }
+
+    int reference_max_sum;
+    int reference_result;
+    {
+      int max_sum = 0;
+      int sum = 0;
+      int result = 0;
+      for (int i = 0; i < n; ++i) {
+        sum += as[i];
+        if (sum > max_sum) {
+          max_sum = sum;
+          result = i + 1;
+        }
+      }
+      reference_max_sum = max_sum;
+      reference_result = result;
+    }
+    std::cout << "Max prefix sum: " << reference_max_sum << " on prefix [0; " << reference_result << ")" << std::endl;
+
+    {
+      timer t;
+      for (int iter = 0; iter < benchmarkingIters; ++iter) {
+        int max_sum = 0;
+        int sum = 0;
+        int result = 0;
+        for (int i = 0; i < n; ++i) {
+          sum += as[i];
+          if (sum > max_sum) {
+            max_sum = sum;
+            result = i + 1;
+          }
+        }
+        EXPECT_THE_SAME(reference_max_sum, max_sum, "CPU result should be consistent!");
+        EXPECT_THE_SAME(reference_result, result, "CPU result should be consistent!");
+        t.nextLap();
+      }
+      std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+      std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    }
+
+    {
+      size_t globalSize = (n + groupSize - 1) / groupSize * groupSize;
+      std::vector<int> buffer(3 * globalSize);
+
+      timer t;
+      for (int i = 0; i < benchmarkingIters; i++) {
+        int max_sum;
+        int res;
+
+        init_buffer(buffer.data(), as.data(), n, globalSize);
+        for (int len = globalSize; len > 1; len /= groupSize) {
+          buffer_gpu.resizeN(3 * len);
+          buffer_gpu.writeN(buffer.data(), 3 * len);
+
+          gpu::WorkSize workSize(groupSize, (len + groupSize - 1) / groupSize * groupSize);
+
+          kernel.exec(workSize, buffer_gpu, len);
+
+          buffer_gpu.readN(buffer.data(), 3 * len);
+          reorder_buffer(buffer.data(), len, groupSize);
+        }
+
+        max_sum = buffer[2];
+        res = buffer[1];
+
+        EXPECT_THE_SAME(reference_max_sum, max_sum, "GPU result should be consistent!");
+        EXPECT_THE_SAME(reference_result, res, "GPU result should be consistent!");
+        t.nextLap();
+      }
+      std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+      std::cout << "GPU: " << (globalSize / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    }
+  }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,64 +1,96 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
 
+#include "cl/sum_cl.h"
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
-    if (a != b) {
-        std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
-        throw std::runtime_error(message);
-    }
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+  if (a != b) {
+    std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
+    throw std::runtime_error(message);
+  }
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
-    int benchmarkingIters = 10;
+int main(int argc, char **argv) {
+  gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-    unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
-    std::vector<unsigned int> as(n, 0);
-    FastRandom r(42);
-    for (int i = 0; i < n; ++i) {
-        as[i] = (unsigned int) r.next(0, std::numeric_limits<unsigned int>::max() / n);
-        reference_sum += as[i];
-    }
+  int benchmarkingIters = 10;
 
-    {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            unsigned int sum = 0;
-            for (int i = 0; i < n; ++i) {
-                sum += as[i];
-            }
-            EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
-            t.nextLap();
-        }
-        std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
-    }
+  unsigned int reference_sum = 0;
+  unsigned int n = 100 * 1000 * 1000;
+  std::vector<unsigned int> as(n, 0);
+  FastRandom r(42);
+  for (int i = 0; i < n; ++i) {
+    as[i] = (unsigned int) r.next(0, std::numeric_limits<unsigned int>::max() / n);
+    reference_sum += as[i];
+  }
 
-    {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            unsigned int sum = 0;
-            #pragma omp parallel for reduction(+:sum)
-            for (int i = 0; i < n; ++i) {
-                sum += as[i];
-            }
-            EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
-            t.nextLap();
-        }
-        std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+  {
+    timer t;
+    for (int iter = 0; iter < benchmarkingIters; ++iter) {
+      unsigned int sum = 0;
+      for (int i = 0; i < n; ++i) {
+        sum += as[i];
+      }
+      EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
+      t.nextLap();
     }
+    std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "CPU:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+  }
 
-    {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+  {
+    timer t;
+    for (int iter = 0; iter < benchmarkingIters; ++iter) {
+      unsigned int sum = 0;
+#pragma omp parallel for reduction(+:sum)
+      for (int i = 0; i < n; ++i) {
+        sum += as[i];
+      }
+      EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
+      t.nextLap();
     }
+    std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "CPU OMP: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+  }
+
+  {
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
+    gpu::gpu_mem_32u as_gpu;
+    as_gpu.resizeN(n);
+    as_gpu.writeN(as.data(), n);
+
+    gpu::gpu_mem_32u sum_gpu;
+    sum_gpu.resizeN(1);
+
+    size_t groupSize = 128;
+    size_t globalWorkSize = (n + groupSize - 1) / groupSize * groupSize;
+    gpu::WorkSize workSize(groupSize, globalWorkSize);
+
+    std::string defines = " -D WORK_GROUP_SIZE=" + to_string(groupSize);
+    ocl::Kernel kernel(sum_kernel, sum_kernel_length, "bad_sum", defines);
+    kernel.compile();
+
+
+    timer t;
+    for (int i = 0; i < benchmarkingIters; ++i) {
+      unsigned int sum = 0;
+      sum_gpu.writeN(&sum, 1);
+      kernel.exec(workSize, as_gpu, sum_gpu, n);
+      sum_gpu.readN(&sum, 1);
+      EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+      t.nextLap();
+    }
+    std::cout << "GPU(bad):" << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "GPU(bad):" << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+  }
 }


### PR DESCRIPTION
A+B:
```
OpenCL devices:
  Device #0: GPU. GeForce GTX 1050. Total memory: 4096 Mb
  Device #1: CPU. Intel(R) Core(TM) i5-8300H CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 12128 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 4851 Mb
Using device #0: GPU. GeForce GTX 1050. Total memory: 4096 Mb
Data generated for n=50000000!
Just example of printf usage: WARP_SIZE=32
```

Mandelbrot (Max GFlops on GeForce was ~1100):
```
OpenCL devices:
  Device #0: GPU. GeForce GTX 1050. Total memory: 4096 Mb
  Device #1: CPU. Intel(R) Core(TM) i5-8300H CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 12128 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 4851 Mb
Using device #0: GPU. GeForce GTX 1050. Total memory: 4096 Mb
CPU: 0.648833+-0.00724377 s
CPU: 15.4123 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.0155+-0.0005 s
GPU: 645.161 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
```

Sum (wrote about strange barrier behaviour with return):
```
OpenCL devices:
  Device #0: GPU. GeForce GTX 1050. Total memory: 4096 Mb
  Device #1: CPU. Intel(R) Core(TM) i5-8300H CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 12128 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 4851 Mb
Using device #0: GPU. GeForce GTX 1050. Total memory: 4096 Mb
CPU:      0.236333+-0.00197203 s
CPU:      423.131 millions/s
CPU OMP:  0.0761667+-0.00323608 s
CPU OMP:  1312.91 millions/s
GPU(bad): 0.01+-0 s
GPU(bad): 10000 millions/s
GPU(opt): 0.0103333+-0.000471405 s
GPU(opt): 9677.42 millions/s
```

PrefixSum:
```
OpenCL devices:
  Device #0: GPU. GeForce GTX 1050. Total memory: 4096 Mb
  Device #1: CPU. Intel(R) Core(TM) i5-8300H CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 12128 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 4851 Mb
Using device #0: GPU. GeForce GTX 1050. Total memory: 4096 Mb
______________________________________________
n=2 values in range: [-1023; 1023]
Max prefix sum: 0 on prefix [0; 0)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0+-0 s
GPU: inf millions/s
______________________________________________
n=4 values in range: [-1023; 1023]
Max prefix sum: 776 on prefix [0; 1)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 0.768 millions/s
______________________________________________
n=8 values in range: [-1023; 1023]
Max prefix sum: 0 on prefix [0; 0)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0+-0 s
GPU: inf millions/s
______________________________________________
n=16 values in range: [-1023; 1023]
Max prefix sum: 1562 on prefix [0; 6)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 0.768 millions/s
______________________________________________
n=32 values in range: [-1023; 1023]
Max prefix sum: 6550 on prefix [0; 22)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 0.768 millions/s
______________________________________________
n=64 values in range: [-1023; 1023]
Max prefix sum: 0 on prefix [0; 0)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0+-0 s
GPU: inf millions/s
______________________________________________
n=128 values in range: [-1023; 1023]
Max prefix sum: 4191 on prefix [0; 34)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0+-0 s
GPU: inf millions/s
______________________________________________
n=256 values in range: [-1023; 1023]
Max prefix sum: 1093 on prefix [0; 4)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000333333+-0.000471405 s
GPU: 0.768 millions/s
______________________________________________
n=512 values in range: [-1023; 1023]
Max prefix sum: 7395 on prefix [0; 316)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000333333+-0.000471405 s
GPU: 1.536 millions/s
______________________________________________
n=1024 values in range: [-1023; 1023]
Max prefix sum: 4662 on prefix [0; 323)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 6.144 millions/s
______________________________________________
n=2048 values in range: [-1023; 1023]
Max prefix sum: 3486 on prefix [0; 55)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000333333+-0.000471405 s
GPU: 6.144 millions/s
______________________________________________
n=4096 values in range: [-1023; 1023]
Max prefix sum: 6013 on prefix [0; 208)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 24.576 millions/s
______________________________________________
n=8192 values in range: [-1023; 1023]
Max prefix sum: 75294 on prefix [0; 6579)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000333333+-0.000471405 s
GPU: 24.576 millions/s
______________________________________________
n=16384 values in range: [-1023; 1023]
Max prefix sum: 92146 on prefix [0; 12399)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000333333+-0.000471405 s
GPU: 49.152 millions/s
______________________________________________
n=32768 values in range: [-1023; 1023]
Max prefix sum: 78744 on prefix [0; 3221)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000833333+-0.000372678 s
GPU: 39.3216 millions/s
______________________________________________
n=65536 values in range: [-1023; 1023]
Max prefix sum: 56352 on prefix [0; 8758)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000833333+-0.000372678 s
GPU: 78.6432 millions/s
______________________________________________
n=131072 values in range: [-1023; 1023]
Max prefix sum: 114622 on prefix [0; 10080)
CPU: 0.000333333+-0.000471405 s
CPU: 393.216 millions/s
GPU: 0.001+-0 s
GPU: 131.072 millions/s
______________________________________________
n=262144 values in range: [-1023; 1023]
Max prefix sum: 228982 on prefix [0; 97875)
CPU: 0.000833333+-0.000372678 s
CPU: 314.573 millions/s
GPU: 0.002+-0 s
GPU: 131.072 millions/s
______________________________________________
n=524288 values in range: [-1023; 1023]
Max prefix sum: 771285 on prefix [0; 524288)
CPU: 0.00133333+-0.000471405 s
CPU: 393.216 millions/s
GPU: 0.00383333+-0.000372678 s
GPU: 136.771 millions/s
______________________________________________
n=1048576 values in range: [-1023; 1023]
Max prefix sum: 378485 on prefix [0; 836658)
CPU: 0.003+-4.1159e-11 s
CPU: 349.525 millions/s
GPU: 0.00683333+-0.000372678 s
GPU: 153.45 millions/s
______________________________________________
n=2097152 values in range: [-1023; 1023]
Max prefix sum: 1625146 on prefix [0; 1558997)
CPU: 0.00566667+-0.000471405 s
CPU: 370.086 millions/s
GPU: 0.013+-0 s
GPU: 161.319 millions/s
______________________________________________
n=4194304 values in range: [-511; 511]
Max prefix sum: 315064 on prefix [0; 4115605)
CPU: 0.0113333+-0.000471405 s
CPU: 370.086 millions/s
GPU: 0.023+-3.29272e-10 s
GPU: 182.361 millions/s
______________________________________________
n=8388608 values in range: [-255; 255]
Max prefix sum: 55893 on prefix [0; 20879)
CPU: 0.022+-4.65661e-10 s
CPU: 381.3 millions/s
GPU: 0.04+-0 s
GPU: 209.715 millions/s
______________________________________________
n=16777216 values in range: [-127; 127]
Max prefix sum: 118369 on prefix [0; 652799)
CPU: 0.0438333+-0.000372678 s
CPU: 382.75 millions/s
GPU: 0.079+-0.00057735 s
GPU: 212.37 millions/s
```

Префиксную сумму писал не долго, но, вообще, проблемы следующие: нету глобальной синхронизации, поэтому не получалось сделать так, чтобы глобальный буффер как-то изменять вне своей области, т.к. нарывался на гонку, в общем пока не успел разобраться как эффективно работать с буффером, ну и поэтому даже не было пока смысла оптимизировать сам kernel.

Upd: переделал работу с буффером вне видеокарты, на работу внутри видеокарты (т.е. не выгружаю лишние разы), стало получше, но теперь хотя бы улучшать можно)