### PR TITLE
Task05 Denis Konoplev Jetbrains

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,4 +1,58 @@
-__kernel void bitonic(__global float* as)
+__kernel void wikipedia_bitonic(__global float* as,
+                                unsigned int max_strip,
+                                unsigned int strip,
+                                unsigned int n)
 {
-    // TODO
+    // total number of work items is n
+    const unsigned int index = get_global_id(0);
+    if (index >= n) {
+        return;
+    }
+    const unsigned int step = strip / 2;
+
+    unsigned int left_idx = index;
+    unsigned int right_idx = index ^ strip;
+    const float is_blue = (left_idx & max_strip) != 0 ? 1.f : 0.f;
+
+    // point of code divergence
+    // half of work items should stop here
+    if (left_idx <= right_idx) {
+        return;
+    }
+
+    const float left = as[left_idx];
+    const float right = as[right_idx];
+
+    as[left_idx] = is_blue * min(left, right) + (1.f - is_blue) * max(left, right);
+    as[right_idx] = is_blue * max(left, right) + (1.f - is_blue) * min(left, right);
 }
+
+
+__kernel void bitonic(__global float* as,
+                      unsigned int global_strip,
+                      unsigned int local_strip,
+                      unsigned int n)
+{
+    // this version fixes code divergence
+    // total number of work items is n/2
+    const unsigned int arrow_id = get_global_id(0);
+
+    if (arrow_id >= n/2) {
+        return;
+    }
+
+    const unsigned int arrows_in_strip = local_strip / 2;
+    const unsigned int arrow_group_id = arrow_id / arrows_in_strip;
+    const unsigned int arrow_group_offset = arrow_id % arrows_in_strip;
+    const unsigned int left_idx = arrow_group_id * local_strip + arrow_group_offset;
+    const unsigned int right_idx = left_idx + arrows_in_strip;
+
+    const float is_blue = (left_idx & global_strip) == 0 ? 1.f : 0.f;
+
+    const float left = as[left_idx];
+    const float right = as[right_idx];
+
+    as[left_idx] = is_blue * min(left, right) + (1.f - is_blue) * max(left, right);
+    as[right_idx] = is_blue * max(left, right) + (1.f - is_blue) * min(left, right);
+}
+


### PR DESCRIPTION
# Bitonic 
Заодно посчитал, сколько занимает data transfer.
```
OpenCL devices:
  Device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 4080 Mb
  Device #1: CPU. Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz. Intel. Total memory: 32768 Mb
  Device #2: GPU. Intel(R) UHD Graphics 630. Total memory: 1536 Mb
Using device #0: GPU. AMD Radeon Pro 5500M Compute Engine. Total memory: 4080 Mb
Data generated for n=33554432!
CPU: 2.67318+-0.0155153 s
CPU: 12.3448 millions/s
GPU data transfer: 0.0238357+-0.000172092 s
GPU data transfer: 1384.48 millions/s

GPU wiki bitonic: 0.620757+-0.00201328 s
GPU wiki bitonic: 53.1609 millions/s
GPU wiki bitonic with transfer: 51.1951 millions/s

GPU: 0.594348+-0.00144596 s
GPU: 55.5231 millions/s
GPU with transfer: 53.3553 millions/s
```

# Radix

todo